### PR TITLE
Add the PlaceAlias table

### DIFF
--- a/geography_loader.py
+++ b/geography_loader.py
@@ -7,6 +7,7 @@ from sqlalchemy.sql.expression import cast
 from model import (
     get_one_or_create,
     Place,
+    PlaceAlias,
 )
 
 class GeographyLoader(object):
@@ -59,8 +60,14 @@ class GeographyLoader(object):
         place.abbreviated_name = abbreviated_name
         place.geography = geography
 
-        # TODO: aliases are ignored since there is currently no
-        # database table that can hold them.
-
+        # We only ever add aliases. If the database contains an alias
+        # for this place that doesn't show up in the metadata, it
+        # may have been created manually.
+        for alias in aliases:
+            name = alias['name']
+            language = alias['language']
+            alias, is_new = get_one_or_create(
+                self._db, PlaceAlias, place=place, name=name, language=language
+            )
         self.places_by_external_id[external_id] = place
         return place, is_new

--- a/model.py
+++ b/model.py
@@ -182,7 +182,7 @@ class Place(Base):
     # The geography of the place itself. It is stored internally as a
     # geometry, which means we have to cast to Geography when doing
     # calculations.
-    geography = Column(Geography(geometry_type='POINT'), nullable=False)
+    geography = Column(Geography(geometry_type='GEOMETRY'), nullable=False)
 
     aliases = relationship("PlaceAlias", backref='place')
 

--- a/model.py
+++ b/model.py
@@ -179,8 +179,11 @@ class Place(Base):
         lazy="joined"
     )
     
-    # The geography of the place itself.
-    geography = Column(Geography(), nullable=False)
+    # The geography of the place itself. Storing it internally as a GEOMETRY
+    # means we have to cast to Geography when doing calculations, but
+    # it lets us store points alongside polygons, which is important for
+    # our purposes.
+    geography = Column(Geography(geometry_type='GEOMETRY'), nullable=False)
 
     aliases = relationship("PlaceAlias", backref='place')
 

--- a/model.py
+++ b/model.py
@@ -179,11 +179,10 @@ class Place(Base):
         lazy="joined"
     )
     
-    # The geography of the place itself. Storing it internally as a GEOMETRY
-    # means we have to cast to Geography when doing calculations, but
-    # it lets us store points alongside polygons, which is important for
-    # our purposes.
-    geography = Column(Geography(geometry_type='GEOMETRY'), nullable=False)
+    # The geography of the place itself. It is stored internally as a
+    # geometry, which means we have to cast to Geography when doing
+    # calculations.
+    geography = Column(Geography(geometry_type='POINT'), nullable=False)
 
     aliases = relationship("PlaceAlias", backref='place')
 

--- a/model.py
+++ b/model.py
@@ -5,11 +5,12 @@ from sqlalchemy import (
     Column,
     ForeignKey,
     Integer,
-    String
+    Unicode,
 )
 from sqlalchemy import (
     create_engine,
-    exc as sa_exc
+    exc as sa_exc,
+    UniqueConstraint,
 )
 from sqlalchemy.exc import (
     IntegrityError
@@ -27,6 +28,7 @@ from sqlalchemy.orm.exc import (
     MultipleResultsFound,
 )
 from sqlalchemy.orm.session import Session
+from sqlalchemy.sql.expression import cast
 
 from geoalchemy2 import Geography
 
@@ -150,19 +152,19 @@ class Place(Base):
     id = Column(Integer, primary_key=True)
 
     # The type of place.
-    type = Column(String(255), index=True, nullable=False)
+    type = Column(Unicode(255), index=True, nullable=False)
 
     # The unique ID given to this place in the data source it was
     # derived from.
-    external_id = Column(String, index=True)
+    external_id = Column(Unicode, index=True)
 
     # The name given to this place by the data source it was
     # derived from.
-    external_name = Column(String, index=True)
+    external_name = Column(Unicode, index=True)
 
     # A canonical abbreviated name for this place. Generally used only
     # for nations and states.
-    abbreviated_name = Column(String, index=True)
+    abbreviated_name = Column(Unicode, index=True)
     
     # The most convenient place that 'contains' this place. For most
     # places the most convenient parent will be a state. For states,
@@ -179,6 +181,20 @@ class Place(Base):
     
     # The geography of the place itself.
     geography = Column(Geography(), nullable=False)
+
+    aliases = relationship("PlaceAlias", backref='place')
+
+    @property
+    def geo(self):
+        """Cast the .geography object to Geography for use in a database
+        query. Otherwise it's sometimes treated as a Geometry object,
+        which results in inaccurate measurements.
+
+        TODO: I would prefer to do without this, but I don't
+        understand enough about PostGIS/Geoalchemy to understand why
+        Geography objects get treated as Geometry objects.
+        """
+        return cast(self.geography, Geography)
     
     def __repr__(self):
         if self.parent:
@@ -193,3 +209,18 @@ class Place(Base):
             self.external_name, self.type, abbr, self.external_id, parent
         )
         return output.encode("utf8")
+
+
+class PlaceAlias(Base):
+
+    """An alternate name for a place."""
+    __tablename__ = 'placealiases'
+
+    id = Column(Integer, primary_key=True)
+    place_id = Column(Integer, ForeignKey('places.id'), index=True)
+    name = Column(Unicode, index=True)
+    language = Column(Unicode(3), index=True)
+
+    __table_args__ = (
+        UniqueConstraint('place_id', 'name', 'language'),
+    )

--- a/tests/test_geography_loader.py
+++ b/tests/test_geography_loader.py
@@ -4,11 +4,12 @@ from nose.tools import (
     set_trace,
 )
 from sqlalchemy import func
-
+from geoalchemy2 import Geography
 from model import (
     get_one,
     get_one_or_create,
     Place,
+    PlaceAlias,
 )
 
 from . import (
@@ -26,7 +27,7 @@ class TestGeographyLoader(DatabaseTest):
     
     def test_load(self):       
         # Load a place identified by a GeoJSON Polygon.
-        metadata = '{"parent_id": null, "name": "77977", "id": "77977", "type": "postal_code"}'
+        metadata = '{"parent_id": null, "name": "77977", "id": "77977", "type": "postal_code", "aliases": [{"name": "The 977", "language": "eng"}]}'
         geography = '{"type": "Polygon", "coordinates": [[[-96.840066, 28.683039], [-96.830637, 28.690131], [-96.835048, 28.693599], [-96.833515, 28.694926], [-96.82657, 28.699584], [-96.822495, 28.695826], [-96.821248, 28.696391], [-96.814249, 28.700983], [-96.772337, 28.722765], [-96.768804, 28.725363], [-96.768564, 28.725046], [-96.767246, 28.723276], [-96.765295, 28.722084], [-96.764568, 28.720456], [-96.76254, 28.718483], [-96.763087, 28.717521], [-96.761814, 28.716488], [-96.761088, 28.713623], [-96.762231, 28.712798], [-96.75967, 28.709812], [-96.781093, 28.677548], [-96.784803, 28.675363], [-96.793788, 28.669546], [-96.791527, 28.667603], [-96.808567, 28.678507], [-96.81505, 28.682946], [-96.820191, 28.684517], [-96.827178, 28.679867], [-96.828626, 28.681719], [-96.831309, 28.680451], [-96.83565, 28.677724], [-96.840066, 28.683039]]]}'
         texas_zip, is_new = self.loader.load(metadata, geography)
         eq_(True, is_new)
@@ -34,9 +35,13 @@ class TestGeographyLoader(DatabaseTest):
         eq_("77977", texas_zip.external_name)
         eq_(None, texas_zip.parent)
         eq_("postal_code", texas_zip.type)
-       
+
+        [alias] = texas_zip.aliases
+        eq_("The 977", alias.name)
+        eq_("eng", alias.language)
+        
         # Load another place identified by a GeoJSON Point.
-        metadata = '{"parent_id": null, "name": "New York", "type": "state", "abbreviated_name": "NY", "id": "NY", "full_name": "New York"}'
+        metadata = '{"parent_id": null, "name": "New York", "type": "state", "abbreviated_name": "NY", "id": "NY", "full_name": "New York", "aliases": [{"name": "New York State", "language": "eng"}]}'
         geography = '{"type": "Point", "coordinates": [-75, 43]}'
         new_york, is_new = self.loader.load(metadata, geography)
         eq_("NY", new_york.abbreviated_name)
@@ -47,15 +52,14 @@ class TestGeographyLoader(DatabaseTest):
         # and Texas. This verifies that the GeoJSON shapes are
         # imported as real-world geographies, not abstract
         # geometries.
-        distance_func = func.ST_Distance(
-            new_york.geography, texas_zip.geography
-        )
+        distance_func = func.ST_Distance(new_york.geo, texas_zip.geo)
         distance_qu = self._db.query().add_columns(distance_func)
         [[distance]] = distance_qu.all()
         eq_(2511, int(distance/1000))
         
-        # Not implemented yet.
-        assert not hasattr(new_york, 'aliases')
+        [alias] = new_york.aliases
+        eq_("New York State", alias.name)
+        eq_("eng", alias.language)
 
         # If we load the same place again, but with a different geography,
         # the Place object is updated.
@@ -65,21 +69,30 @@ class TestGeographyLoader(DatabaseTest):
         eq_(new_york, new_york_2)
 
         # This changes the distance between the two points.
-        distance_func = func.ST_Distance(
-            new_york_2.geography, texas_zip.geography
-        )
+        distance_func = func.ST_Distance(new_york_2.geo, texas_zip.geo)
         distance_qu = self._db.query().add_columns(distance_func)
         [[distance]] = distance_qu.all()
         eq_(2638, int(distance/1000))
         
     def test_load_ndjson(self):
+        # Create a preexisting Place with an alias.
+        old_us, is_new = get_one_or_create(
+            self._db, Place, parent=None, external_name="United States",
+            external_id="US", type="nation", geography='POINT(-75 43)'
+        )
+        eq_(None, old_us.abbreviated_name)
+        old_alias = get_one_or_create(
+            self._db, PlaceAlias, name="USA", language="eng", place=old_us
+        )
+        old_us_geography = old_us.geography
+        
         # Load a small NDJSON "file" containing information about
         # three places.
-        test_ndjson = """{"parent_id": null, "name": "United States", "full_name": null, "aliases": [], "type": "nation", "abbreviated_name": "US", "id": "US"}
+        test_ndjson = """{"parent_id": null, "name": "United States", "aliases": [{"name" : "The Good Old U. S. of A.", "language": "eng"}], "type": "nation", "abbreviated_name": "US", "id": "US"}
 {"type": "Point", "coordinates": [-159.459551, 54.948652]}
-{"parent_id": "US", "name": "Alabama", "full_name": null, "aliases": [], "type": "state", "abbreviated_name": "AL", "id": "01"}
+{"parent_id": "US", "name": "Alabama", "aliases": [], "type": "state", "abbreviated_name": "AL", "id": "01"}
 {"type": "Point", "coordinates": [-88.053375, 30.506987]}
-{"parent_id": "01", "name": "Montgomery", "full_name": null, "aliases": [], "type": "city", "abbreviated_name": null, "id": "0151000"}
+{"parent_id": "01", "name": "Montgomery", "aliases": [], "type": "city", "abbreviated_name": null, "id": "0151000"}
 {"type": "Point", "coordinates": [-86.034128, 32.302979]}"""
         input = StringIO(test_ndjson)
         [(us, ignore), (alabama, ignore), (montgomery, ignore)] = list(
@@ -94,12 +107,27 @@ class TestGeographyLoader(DatabaseTest):
         eq_(None, us.parent)
         eq_(us, alabama.parent)
         eq_(alabama, montgomery.parent)
+
+        # The place that existed before we ran the loader is still the
+        # same database object, but it has had additional information
+        # associated with it.
+        eq_(us, old_us)
+        eq_("US", us.abbreviated_name)
+
+        # And its geography has been updated.
+        assert old_us_geography != us.geography
+
+        # Its preexisting alias has been preserved, and a new alias added.
+        [new_alias, old_alias] = sorted(us.aliases, key=lambda x: x.name)
+        eq_("USA", old_alias.name)
+        
+        eq_("The Good Old U. S. of A.", new_alias.name)
+        eq_("eng", new_alias.language)
         
         # We can measure the distance in kilometers between the point
         # chosen to represent 'Montgomery' and the point chosen to
         # represent 'Alabama'.
-        distance_func = func.ST_Distance(
-            montgomery.geography, alabama.geography
-        )
+        distance_func = func.ST_Distance(montgomery.geo, alabama.geo)
         [[distance]] = self._db.query().add_columns(distance_func).all()
+        print distance
         eq_(276, int(distance/1000))

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -8,6 +8,7 @@ from model import (
     get_one,
     get_one_or_create,
     Place,
+    PlaceAlias,
 )
 
 from . import (
@@ -70,3 +71,16 @@ class TestPlace(DatabaseTest):
             ],
             [(x[0].external_name, int(x[1]/1000)) for x in places]
         )
+
+    def test_aliases(self):
+        new_york, is_new = get_one_or_create(
+            self._db, Place, type=Place.STATE, external_id='04',
+            external_name='New York',
+            create_method_kwargs=dict(geography='POINT(-75 43)')
+        )
+        alias, is_new = get_one_or_create(
+            self._db, PlaceAlias, place=new_york,
+            name='New York State', language='eng'
+        )
+        eq_([alias], new_york.aliases)
+        

--- a/tests/test_scripts.py
+++ b/tests/test_scripts.py
@@ -1,4 +1,7 @@
-from nose.tools import set_trace
+from nose.tools import (
+    set_trace,
+    eq_,
+)
 from StringIO import StringIO
 
 from model import (


### PR DESCRIPTION
This branch completes the import of data from geojson-places-us by adding a PlaceAlias class which contains alternate names for places.

I don't expect to be using PlaceAlias.language very soon, but I want it in place from the beginning. I think it will be useful for libraries in countries that have more than one official language, like Canada and South Africa.

The other big change here is I added `Place.geo`, which casts the `Place.geography` field to `Geography`. 
Our ORM defines the field as a Geography field, but internally the data is stored as though it were a Geometry field. Without the cast, this means database functions treat places as shapes on a flat plane of undetermined dimensions, rather than shapes on the Earth with distances measured in meters.

I was not able to find any way of forcing the `geography` field to always be treated as Geometry without an expicit cast. Supposedly "Standard geometry type data will autocast to geography if it is of SRID 4326." That is the case for this field but it's not happening...