### PR TITLE
Create `LibraryAlias` and implement basic search by library name

### DIFF
--- a/model.py
+++ b/model.py
@@ -161,8 +161,13 @@ class Library(Base):
     @classmethod
     def for_name(cls, _db, name):
         """Find a library whose name or alias matches the given name."""
+
+        # We allow for minor misspellings in the official name,
+        # but not in aliases (which are likely to be acronyms)
+        name_close_enough = func.levenshtein(func.lower(Library.name),
+                                             func.lower(name)) < 2
         qu = _db.query(Library).outerjoin(Library.aliases).filter(
-            or_(Library.name.ilike(name), LibraryAlias.name.ilike(name))
+            or_(name_close_enough, LibraryAlias.name.ilike(name))
         )
         return qu
     

--- a/model.py
+++ b/model.py
@@ -194,6 +194,7 @@ class Library(Base):
                 distance.asc())
         return qu
 
+
 class LibraryAlias(Base):
 
     """An alternate name for a library."""

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -132,6 +132,12 @@ class TestLibrary(DatabaseTest):
         eq_([brooklyn],
             list(Library.for_name(self._db, "Brooklyn Public Library"))
         )
+
+        # We can tolerate a small number of typos in the official name
+        # of the library.
+        eq_([brooklyn],
+            list(Library.for_name(self._db, "Brooklyn Public Libary"))
+        )
         
         boston, is_new = get_one_or_create(
             self._db, Library, name="Boston Public Library"
@@ -143,9 +149,12 @@ class TestLibrary(DatabaseTest):
                 library=library
             )
         eq_(
-            set([brooklyn, boston]), set(Library.for_name(self._db, "BPL"))
+            set([brooklyn, boston]), set(Library.for_name(self._db, "bpl"))
         )
-            
+
+        # We do not tolerate typos in aliases.
+        eq_([], list(Library.for_name(self._db, "OPL")))
+        
     def test_nearby(self):
         # Create two libraries. One serves New York City, and one serves
         # the entire state of Connecticut.

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -136,7 +136,7 @@ class TestLibrary(DatabaseTest):
         # We can tolerate a small number of typos in the official name
         # of the library.
         eq_([brooklyn],
-            list(Library.for_name(self._db, "Brooklyn Public Libary"))
+            list(Library.for_name(self._db, "brooklyn public libary"))
         )
         
         boston, is_new = get_one_or_create(

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -8,6 +8,7 @@ from model import (
     get_one,
     get_one_or_create,
     Library,
+    LibraryAlias,
     Place,
     PlaceAlias,
 )
@@ -123,6 +124,28 @@ class TestLibrary(DatabaseTest):
         eq_(zip, service_area.place)
         eq_(nypl, service_area.library)
 
+    def test_aliases(self):
+        brooklyn, is_new = get_one_or_create(
+            self._db, Library, name="Brooklyn Public Library"
+        )
+
+        eq_([brooklyn],
+            list(Library.for_name(self._db, "Brooklyn Public Library"))
+        )
+        
+        boston, is_new = get_one_or_create(
+            self._db, Library, name="Boston Public Library"
+        )
+
+        for library in (brooklyn, boston):
+            get_one_or_create(
+                self._db, LibraryAlias, name="BPL", language=None,
+                library=library
+            )
+        eq_(
+            set([brooklyn, boston]), set(Library.for_name(self._db, "BPL"))
+        )
+            
     def test_nearby(self):
         # Create two libraries. One serves New York City, and one serves
         # the entire state of Connecticut.


### PR DESCRIPTION
This branch creates the concept of "library alias", which is almost exactly the same as "place alias", but for libraries. It's used to create alternate names for libraries (e.g. "NYPL" for the New York Public Library).

This branch also implements `Library.by_name`, which performs a slightly fuzzy match against a library's official name, and a less fuzzy match against its aliases.