### PR TITLE
Added code that turns an IP address into a geometric point.

### DIFF
--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -1,0 +1,16 @@
+from nose.tools import (
+    set_trace,
+    eq_,
+)
+from util import GeometryUtility
+
+class TestGeometryUtility(object):
+
+    def test_point(self):
+        point = GeometryUtility.point("80", "-4")
+        eq_('SRID=4326;POINT (-4 80)', point)
+        
+    def test_point_from_ip(self):
+        point = GeometryUtility.point_from_ip("65.88.88.124")
+        eq_('SRID=4326;POINT (-73.9813 40.7769)', point)
+        

--- a/util.py
+++ b/util.py
@@ -1,6 +1,7 @@
 from nose.tools import set_trace
 from sqlalchemy import func
 from geoalchemy2 import Geometry
+from geoip import geolite2
 
 class GeometryUtility(object):
 
@@ -14,8 +15,16 @@ class GeometryUtility(object):
         return geometry
 
     @classmethod
+    def point_from_ip(cls, ip_address):
+        match = geolite2.lookup(ip_address)
+        if match is None:
+            return None
+        return cls.point(*match.location)        
+    
+    @classmethod
     def point(cls, latitude, longitude):
         """Convert latitude/longitude to a string that can be
         used as a Geometry.
         """
         return 'SRID=4326;POINT (%s %s)' % (longitude, latitude)
+


### PR DESCRIPTION
This tiny branch uses the python-geoip-geolite2 database and library to turn IP addresses into geographic points representing approximate latitude and longitude.