### PR TITLE
Add initial OPDS support

### DIFF
--- a/model.py
+++ b/model.py
@@ -180,6 +180,10 @@ class Library(Base):
     # The official name of the library.
     name = Column(Unicode, index=True)
 
+    # A URN that uniquely identifies the library. This is the URN
+    # served by the library's Authentication for OPDS document.
+    urn = Column(Unicode, index=True)
+    
     # Human-readable explanation of who the library serves.
     description = Column(Unicode)
 
@@ -187,7 +191,7 @@ class Library(Base):
     opds_url = Column(Unicode)
 
     # The URL to the library's web page.
-    html_url = Column(Unicode)
+    web_url = Column(Unicode)
     
     # When the library's record was last updated.
     timestamp = Column(DateTime, index=True,
@@ -196,6 +200,9 @@ class Library(Base):
 
     # The library's logo.
     logo = Column(Binary)
+
+    # TODO: We need fields for the short library name and shared
+    # secret for Adobe purposes.
     
     aliases = relationship("LibraryAlias", backref='library')
     service_areas = relationship('ServiceArea', backref='library')
@@ -431,7 +438,7 @@ class Library(Base):
         long_value_is_approximate_match = (is_long & close_enough)
         exact_match = field.ilike(value)
         return or_(long_value_is_approximate_match, exact_match)
-
+    
     @property
     def logo_data_uri(self):
         """Return the logo as a data: URI."""

--- a/model.py
+++ b/model.py
@@ -438,6 +438,14 @@ class Library(Base):
         long_value_is_approximate_match = (is_long & close_enough)
         exact_match = field.ilike(value)
         return or_(long_value_is_approximate_match, exact_match)
+
+    @property
+    def urn_uri(self):
+        "Return the URN as a urn: URI."
+        if self.urn.startswith('urn:'):
+            return self.urn
+        else:
+            return 'urn:' + self.urn
     
     @property
     def logo_data_uri(self):

--- a/model.py
+++ b/model.py
@@ -1,11 +1,15 @@
+import base64
 from config import Configuration
+import datetime
 import logging
 from nose.tools import set_trace
 import re
 import warnings
 from psycopg2.extensions import adapt as sqlescape
 from sqlalchemy import (
+    Binary,
     Column,
+    DateTime,
     ForeignKey,
     Integer,
     Unicode,
@@ -176,6 +180,23 @@ class Library(Base):
     # The official name of the library.
     name = Column(Unicode, index=True)
 
+    # Human-readable explanation of who the library serves.
+    description = Column(Unicode)
+
+    # The URL to the library's OPDS server.
+    opds_url = Column(Unicode)
+
+    # The URL to the library's web page.
+    html_url = Column(Unicode)
+    
+    # When the library's record was last updated.
+    timestamp = Column(DateTime, index=True,
+                       default=lambda: datetime.datetime.utcnow(),
+                       onupdate=lambda: datetime.datetime.utcnow())
+
+    # The library's logo.
+    logo = Column(Binary)
+    
     aliases = relationship("LibraryAlias", backref='library')
     service_areas = relationship('ServiceArea', backref='library')
 
@@ -410,6 +431,13 @@ class Library(Base):
         long_value_is_approximate_match = (is_long & close_enough)
         exact_match = field.ilike(value)
         return or_(long_value_is_approximate_match, exact_match)
+
+    @property
+    def logo_data_uri(self):
+        """Return the logo as a data: URI."""
+        if not self.logo:
+            return None
+        return "data:image/png;base64,%s" % base64.b64encode(self.logo)
 
 
 class LibraryAlias(Base):

--- a/opds.py
+++ b/opds.py
@@ -154,7 +154,7 @@ class NavigationFeed(OPDSFeed):
     @classmethod
     def library_entry(cls, library):
         entry = AtomFeed.entry(
-            AtomFeed.id(library.urn),
+            AtomFeed.id(library.urn_uri),
             AtomFeed.title(library.name),
             AtomFeed.updated(cls._strftime(library.timestamp))
         )

--- a/opds.py
+++ b/opds.py
@@ -9,31 +9,15 @@ class AtomFeed(object):
     TIME_FORMAT = '%Y-%m-%dT%H:%M:%SZ%z'
 
     ATOM_NS = 'http://www.w3.org/2005/Atom'
-    APP_NS = 'http://www.w3.org/2007/app'
-    #xhtml_ns = 'http://www.w3.org/1999/xhtml'
-    DCTERMS_NS = 'http://purl.org/dc/terms/'
     OPDS_NS = 'http://opds-spec.org/2010/catalog'
-    SCHEMA_NS = 'http://schema.org/'
-    DRM_NS = 'http://librarysimplified.org/terms/drm'
-    
-    SIMPLIFIED_NS = "http://librarysimplified.org/terms/"
-    BIBFRAME_NS = "http://bibframe.org/vocab/"
 
     nsmap = {
         None: ATOM_NS,
-        'app': APP_NS,
-        'dcterms' : DCTERMS_NS,
         'opds' : OPDS_NS,
-        'drm' : DRM_NS,
-        'schema' : SCHEMA_NS,
-        'simplified' : SIMPLIFIED_NS,
-        'bibframe' : BIBFRAME_NS,
     }
 
     default_typemap = {datetime: lambda e, v: _strftime(v)}
     E = builder.ElementMaker(typemap=default_typemap, nsmap=nsmap)
-    SIMPLIFIED = builder.ElementMaker(typemap=default_typemap, nsmap=nsmap, namespace=SIMPLIFIED_NS)
-    SCHEMA = builder.ElementMaker(typemap=default_typemap, nsmap=nsmap, namespace=SCHEMA_NS)
 
     @classmethod
     def _strftime(self, date):
@@ -54,7 +38,6 @@ class AtomFeed(object):
 
     @classmethod
     def add_link_to_entry(cls, entry, children=None, **kwargs):
-        #links.append(E.link(rel=rel, href=url, type=image_type))
         link = cls.E.link(**kwargs)
         entry.append(link)
         if children:
@@ -136,6 +119,7 @@ class AtomFeed(object):
 
         string_tree = etree.tostring(self.feed, pretty_print=True)
         return string_tree.encode("utf8")
+
 
 class OPDSFeed(AtomFeed):
 

--- a/opds.py
+++ b/opds.py
@@ -1,0 +1,211 @@
+import datetime
+import logging
+
+from lxml import builder, etree
+from nose.tools import set_trace
+
+class AtomFeed(object):
+
+    TIME_FORMAT = '%Y-%m-%dT%H:%M:%SZ%z'
+
+    ATOM_NS = 'http://www.w3.org/2005/Atom'
+    APP_NS = 'http://www.w3.org/2007/app'
+    #xhtml_ns = 'http://www.w3.org/1999/xhtml'
+    DCTERMS_NS = 'http://purl.org/dc/terms/'
+    OPDS_NS = 'http://opds-spec.org/2010/catalog'
+    SCHEMA_NS = 'http://schema.org/'
+    DRM_NS = 'http://librarysimplified.org/terms/drm'
+    
+    SIMPLIFIED_NS = "http://librarysimplified.org/terms/"
+    BIBFRAME_NS = "http://bibframe.org/vocab/"
+
+    nsmap = {
+        None: ATOM_NS,
+        'app': APP_NS,
+        'dcterms' : DCTERMS_NS,
+        'opds' : OPDS_NS,
+        'drm' : DRM_NS,
+        'schema' : SCHEMA_NS,
+        'simplified' : SIMPLIFIED_NS,
+        'bibframe' : BIBFRAME_NS,
+    }
+
+    default_typemap = {datetime: lambda e, v: _strftime(v)}
+    E = builder.ElementMaker(typemap=default_typemap, nsmap=nsmap)
+    SIMPLIFIED = builder.ElementMaker(typemap=default_typemap, nsmap=nsmap, namespace=SIMPLIFIED_NS)
+    SCHEMA = builder.ElementMaker(typemap=default_typemap, nsmap=nsmap, namespace=SCHEMA_NS)
+
+    @classmethod
+    def _strftime(self, date):
+        """
+        Format a date the way Atom likes it (RFC3339?)
+        """
+        return date.strftime(self.TIME_FORMAT)
+
+
+    @classmethod
+    def add_link_to_feed(cls, feed, children=None, **kwargs):
+        link = cls.E.link(**kwargs)
+        feed.append(link)
+        if children:
+            for i in children:
+                link.append(i)
+
+
+    @classmethod
+    def add_link_to_entry(cls, entry, children=None, **kwargs):
+        #links.append(E.link(rel=rel, href=url, type=image_type))
+        link = cls.E.link(**kwargs)
+        entry.append(link)
+        if children:
+            for i in children:
+                link.append(i)
+
+
+    @classmethod
+    def author(cls, *args, **kwargs):
+        return cls.E.author(*args, **kwargs)
+
+
+    @classmethod
+    def category(cls, *args, **kwargs):
+        return cls.E.category(*args, **kwargs)
+
+
+    @classmethod
+    def entry(cls, *args, **kwargs):
+        return cls.E.entry(*args, **kwargs)
+
+
+    @classmethod
+    def id(cls, *args, **kwargs):
+        return cls.E.id(*args, **kwargs)
+
+
+    @classmethod
+    def link(cls, *args, **kwargs):
+        return cls.E.link(*args, **kwargs)
+
+
+    @classmethod
+    def makeelement(cls, *args, **kwargs):
+        return cls.E._makeelement(*args, **kwargs)
+
+
+    @classmethod
+    def name(cls, *args, **kwargs):
+        return cls.E.name(*args, **kwargs)
+
+
+    @classmethod
+    def schema_(cls, field_name):
+        return "{%s}%s" % (cls.SCHEMA_NS, field_name)
+
+    @classmethod
+    def summary(cls, *args, **kwargs):
+        return cls.E.summary(*args, **kwargs)
+
+
+    @classmethod
+    def title(cls, *args, **kwargs):
+        return cls.E.title(*args, **kwargs)
+
+
+    @classmethod
+    def update(cls, *args, **kwargs):
+        return cls.E.update(*args, **kwargs)
+
+
+    @classmethod
+    def updated(cls, *args, **kwargs):
+        return cls.E.updated(*args, **kwargs)
+
+
+    def __init__(self, title, url):
+        self.feed = self.E.feed(
+            self.E.id(url),
+            self.E.title(title),
+            self.E.updated(self._strftime(datetime.datetime.utcnow())),
+            self.E.link(href=url, rel="self"),
+        )
+
+
+    def __unicode__(self):
+        if self.feed is None:
+            return None
+
+        string_tree = etree.tostring(self.feed, pretty_print=True)
+        return string_tree.encode("utf8")
+
+class OPDSFeed(AtomFeed):
+
+    GENERIC_OPDS_TYPE = "application/atom+xml;profile=opds-catalog"
+    NAVIGATION_FEED_TYPE = GENERIC_OPDS_TYPE + ";kind=navigation"
+    ENTRY_TYPE = "application/atom+xml;type=entry;profile=opds-catalog"
+
+    CATALOG_REL = "http://opds-spec.org/catalog"
+    THUMBNAIL_REL = "http://opds-spec.org/image/thumbnail"
+
+
+class Annotator(object):
+
+    def annotate_feed(self, feed):
+        pass
+
+    
+class NavigationFeed(OPDSFeed):
+
+    def __init__(self, _db, title, url, libraries, annotator=None):
+        """Turn a list of libraries into a feed."""
+        super(NavigationFeed, self).__init__(title, url)
+        
+        if not annotator:
+            annotator = Annotator()
+        self.annotator = annotator
+       
+        for library in libraries:
+            self.feed.append(self.library_entry(library))
+        annotator.annotate_feed(self)
+            
+    @classmethod
+    def library_entry(cls, library):
+        entry = AtomFeed.entry(
+            AtomFeed.id(library.urn),
+            AtomFeed.title(library.name),
+            AtomFeed.updated(cls._strftime(library.timestamp))
+        )
+        
+        # Add description.
+        if library.description:
+            content = AtomFeed.E.content(
+                type="text"
+            )
+            content.text = library.description
+            entry.append(content)
+        
+        # Add links.
+        if library.opds_url:
+            AtomFeed.add_link_to_entry(
+                entry,
+                href=library.opds_url,
+                rel=cls.CATALOG_REL,
+                type=cls.GENERIC_OPDS_TYPE
+            )
+        
+        if library.web_url:
+            AtomFeed.add_link_to_entry(
+                entry,
+                href=library.web_url,
+                rel="alternate",
+                type="text/html"
+            )
+
+        if library.logo:
+            AtomFeed.add_link_to_entry(
+                entry,
+                href=library.logo_data_uri,
+                type="image/png",
+                rel=cls.THUMBNAIL_REL
+            )
+
+        return entry

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
+feedparser
 flask
 flask-sqlalchemy-session
 geoalchemy2

--- a/testing.py
+++ b/testing.py
@@ -109,6 +109,7 @@ class DatabaseTest(object):
     def _library(self, name=None, service_areas=[]):
         name = name or self._str
         library, ignore = get_one_or_create(self._db, Library, name=name)
+        library.urn = self._str
         for place in service_areas:
             get_one_or_create(self._db, ServiceArea, library=library,
                               place=place)

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -3,6 +3,8 @@ from nose.tools import (
     set_trace,
 )
 from sqlalchemy import func
+import base64
+import datetime
 
 from model import (
     get_one,
@@ -122,6 +124,25 @@ class TestPlace(DatabaseTest):
 
 class TestLibrary(DatabaseTest):
 
+    def test_timestamp(self):
+        """Timestamp gets automatically set on database commit."""
+        nypl = self._library("New York Public Library")
+        first_modified = nypl.timestamp
+        now = datetime.datetime.utcnow()
+        self._db.commit()
+        assert (now-first_modified).seconds < 2
+
+        nypl.opds_url = "http://library/"
+        self._db.commit()
+        assert nypl.timestamp > first_modified
+
+    def test_logo_data_uri(self):
+        """The library's logo can be converted into a data: URI."""
+        nypl = self._library("New York Public Library")
+        nypl.logo = "Fake logo"
+        expect = 'data:image/png;base64,' + base64.b64encode(nypl.logo)
+        eq_(expect, nypl.logo_data_uri)
+        
     def test_library_service_area(self):
         zip = self.zip_10018
         nypl = self._library("New York Public Library", service_areas=[zip])

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -136,6 +136,13 @@ class TestLibrary(DatabaseTest):
         self._db.commit()
         assert nypl.timestamp > first_modified
 
+    def test_urn_uri(self):
+        nypl = self._library("New York Public Library")
+        nypl.urn = 'foo'
+        eq_("urn:foo", nypl.urn_uri)
+        nypl.urn = 'urn:bar'
+        eq_('urn:bar', nypl.urn_uri)
+        
     def test_logo_data_uri(self):
         """The library's logo can be converted into a data: URI."""
         nypl = self._library("New York Public Library")

--- a/tests/test_opds.py
+++ b/tests/test_opds.py
@@ -57,7 +57,7 @@ class TestOPDS(DatabaseTest):
         feed = feedparser.parse(entry)
         [entry] = feed['entries']
         eq_(library.name, entry['title'])
-        eq_(library.urn, entry['id'])
+        eq_(library.urn_uri, entry['id'])
         [content] = entry['content']
         eq_(library.description, content['value'])
         eq_("text/plain", content['type'])

--- a/tests/test_opds.py
+++ b/tests/test_opds.py
@@ -28,16 +28,18 @@ class TestOPDS(DatabaseTest):
             TestAnnotator()
         )
         feed = unicode(feed)
-        # The annotator modified the feed.
+        parsed = feedparser.parse(feed)
+
+        # The feed is labeled appropriately.
+        eq_("A Feed!", parsed['feed']['title'])
+        eq_("http://url/", parsed['feed']['link'])
+        
+        # The annotator modified the feed in passing.
         assert (
             '<randomtag>Random text inserted by annotator.</randomtag>'
             in feed
         )
-
-        parsed = feedparser.parse(feed)
-        eq_("A Feed!", parsed['feed']['title'])
-        eq_("http://url/", parsed['feed']['link'])
-
+        
         # Each library became an entry in the feed.
         eq_([l1.name, l2.name], [x['title'] for x in parsed['entries']])
         

--- a/tests/test_opds.py
+++ b/tests/test_opds.py
@@ -35,6 +35,9 @@ class TestOPDS(DatabaseTest):
         )
 
         parsed = feedparser.parse(feed)
+        eq_("A Feed!", parsed['feed']['title'])
+        eq_("http://url/", parsed['feed']['link'])
+
         # Each library became an entry in the feed.
         eq_([l1.name, l2.name], [x['title'] for x in parsed['entries']])
         

--- a/tests/test_opds.py
+++ b/tests/test_opds.py
@@ -36,8 +36,7 @@ class TestOPDS(DatabaseTest):
 
         parsed = feedparser.parse(feed)
         # Each library became an entry in the feed.
-        eq_(["The New York Public Library", "Brooklyn Public Library"],
-            [x['title'] for x in parsed['entries']])
+        eq_([l1.name, l2.name], [x['title'] for x in parsed['entries']])
         
     def test_library_entry(self):
 

--- a/tests/test_opds.py
+++ b/tests/test_opds.py
@@ -1,0 +1,76 @@
+from nose.tools import (
+    eq_,
+    set_trace,
+)
+
+import feedparser
+from lxml import etree
+
+from . import (
+    DatabaseTest,
+)
+
+from opds import NavigationFeed
+
+class TestOPDS(DatabaseTest):
+
+    def test_library_feed(self):
+        l1 = self._library("The New York Public Library")
+        l2 = self._library("Brooklyn Public Library")
+        class TestAnnotator(object):
+            def annotate_feed(self, feed_obj):
+                new_tag = feed_obj.E.randomtag()
+                new_tag.text = "Random text inserted by annotator."
+                feed_obj.feed.append(new_tag)
+                
+        feed = NavigationFeed(
+            self._db, "A Feed!", "http://url/", [l1, l2],
+            TestAnnotator()
+        )
+        feed = unicode(feed)
+        # The annotator modified the feed.
+        assert (
+            '<randomtag>Random text inserted by annotator.</randomtag>'
+            in feed
+        )
+
+        parsed = feedparser.parse(feed)
+        # Each library became an entry in the feed.
+        eq_(["The New York Public Library", "Brooklyn Public Library"],
+            [x['title'] for x in parsed['entries']])
+        
+    def test_library_entry(self):
+
+        library = self._library("The New York Public Library")
+        library.urn = "123-abc"
+        library.description = "It's a wonderful library."
+        library.opds_url = "https://opds/"
+        library.web_url = "https://nypl.org/"
+        library.logo = "Fake logo"
+        
+        entry = NavigationFeed.library_entry(library)
+        entry = etree.tostring(entry)
+        feed = feedparser.parse(entry)
+        [entry] = feed['entries']
+        eq_(library.name, entry['title'])
+        eq_(library.urn, entry['id'])
+        [content] = entry['content']
+        eq_(library.description, content['value'])
+        eq_("text/plain", content['type'])
+
+        eq_(entry['updated'], NavigationFeed._strftime(library.timestamp))
+
+        [web, opds, logo] = sorted(entry['links'], key=lambda x: x['rel'])
+
+        eq_(library.web_url, web['href'])
+        eq_("alternate", web['rel'])
+        eq_("text/html", web['type'])
+
+        eq_(library.opds_url, opds['href'])
+        eq_(NavigationFeed.CATALOG_REL, opds['rel'])
+        eq_(NavigationFeed.GENERIC_OPDS_TYPE, opds['type'])
+
+        eq_(library.logo_data_uri, logo['href'])
+        eq_(NavigationFeed.THUMBNAIL_REL, logo['rel'])
+        eq_("image/png", logo['type'])
+


### PR DESCRIPTION
This branch adds some fields to the `libraries` table which we want to use in OPDS feeds, and implements the ability to turn a list of libraries into an OPDS navigation feed. The OPDS generation code is copied from  LS core. I also copied the idea of an `Annotator`, which will be used when I start writing the app server to insert links to the search interface, and any other app-server-specific information.