### PR TITLE
Add some command-line scripts

### DIFF
--- a/bin/add_library
+++ b/bin/add_library
@@ -1,0 +1,9 @@
+#!/usr/bin/env python
+"""Add a library to the system."""
+import os
+import sys
+bin_dir = os.path.split(__file__)[0]
+package_dir = os.path.join(bin_dir, "..")
+sys.path.append(os.path.abspath(package_dir))
+from scripts import AddLibraryScript
+AddLibraryScript().run()

--- a/bin/search
+++ b/bin/search
@@ -1,0 +1,9 @@
+#!/usr/bin/env python
+"""Perform a command-line search for libraries that serve a given area."""
+import os
+import sys
+bin_dir = os.path.split(__file__)[0]
+package_dir = os.path.join(bin_dir, "..")
+sys.path.append(os.path.abspath(package_dir))
+from scripts import SearchLibraryScript
+SearchLibraryScript().run()

--- a/bin/search_places
+++ b/bin/search_places
@@ -1,0 +1,9 @@
+#!/usr/bin/env python
+"""Look up information about places in the system."""
+import os
+import sys
+bin_dir = os.path.split(__file__)[0]
+package_dir = os.path.join(bin_dir, "..")
+sys.path.append(os.path.abspath(package_dir))
+from scripts import SearchPlacesScript
+SearchPlacesScript().run()

--- a/model.py
+++ b/model.py
@@ -207,6 +207,8 @@ class Library(Base):
     aliases = relationship("LibraryAlias", backref='library')
     service_areas = relationship('ServiceArea', backref='library')
 
+    __table_args__ = (UniqueConstraint('urn'),)
+
     @classmethod
     def nearby(cls, _db, latitude, longitude, max_radius=150):
         """Find libraries whose service areas include or are close to the

--- a/model.py
+++ b/model.py
@@ -274,10 +274,12 @@ class Library(Base):
         if not query:
             # No query, no results.
             return []
-        here = GeometryUtility.point(latitude, longitude)
-
+        if latitude and longitude:
+            here = GeometryUtility.point(latitude, longitude)
+        else:
+            here = None
+            
         library_query, place_query, place_type = cls.query_parts(query)
-
         # We start with libraries that match the name query.
         if library_query:
             libraries_for_name = cls.search_by_library_name(

--- a/scripts.py
+++ b/scripts.py
@@ -1,3 +1,4 @@
+from nose.tools import set_trace
 import argparse
 import logging
 import os
@@ -113,11 +114,27 @@ class SearchPlacesScript(Script):
 
     def run(self, cmd_args=None, stdout=sys.stdout):
         parsed = self.parse_command_line(self._db, cmd_args)
-        print parsed.name
         for place in self._db.query(Place).filter(
                 Place.external_name.in_(parsed.name)
         ):
             stdout.write(place)
+            stdout.write("\n")
+
+
+class SearchLibraryScript(Script):
+    """Command-line interface to the library search."""
+    @classmethod
+    def arg_parser(cls):
+        parser = super(SearchLibraryScript, cls).arg_parser()
+        parser.add_argument(
+            'query', nargs=1, help='Search query.'
+        )
+        return parser
+
+    def run(self, cmd_args=None, stdout=sys.stdout):
+        parsed = self.parse_command_line(self._db, cmd_args)
+        for library in Library.search(self._db, None, None, parsed.query[0]):
+            stdout.write("%s: %s" % (library.name, library.opds_url))
             stdout.write("\n")
 
 

--- a/tests/test_scripts.py
+++ b/tests/test_scripts.py
@@ -5,10 +5,13 @@ from nose.tools import (
 from StringIO import StringIO
 
 from model import (
+    Library,
     Place,
 )
 from scripts import (
+    AddLibraryScript,
     LoadPlacesScript,
+    SearchPlacesScript,
 )
 from . import (
     DatabaseTest
@@ -33,4 +36,54 @@ class TestLoadPlacesScript(DatabaseTest):
         eq_(set(["United States", "Alabama", "Montgomery"]),
             set([x.external_name for x in places]))
         eq_(set(["US", "01", "0151000"]), set([x.external_id for x in places]))
+
+
+class TestSearchPlacesScript(DatabaseTest):
+
+    def test_run(self):
+        nys = self.new_york_state
+        ct = self.connecticut_state
+        nyc = self.new_york_city
+
+        # Run the script...
+        output = StringIO()
+        script = SearchPlacesScript(self._db)
+        script.run(["New York"], stdout=output)
+
+        # We found the two places called 'New York', but not the other
+        # place.
+        actual_output = output.getvalue()
+        assert repr(nys) in actual_output
+        assert repr(nyc) in actual_output
+        assert 'Connecticut' not in actual_output
+
+
+class TestAddLibraryScript(DatabaseTest):
+
+    def test_run(self):
+        nyc = self.new_york_city
+        args = ['--name=The New York Public Library',
+                '--urn=1236662b-66cf-3068-af58-95385f299b4f',
+                '--place=' + nyc.external_id,
+                '--alias=NYPL',
+                '--web=https://nypl.org/',
+                '--opds=https://circulation.librarysimplified.org/',
+                '--description=Serving the five boroughs of New York, NY.']
+        script = AddLibraryScript(self._db)
+        script.run(cmd_args=args)
+
+        # A library was created with the given specs.
+        [library] = self._db.query(Library).all()
+
+        eq_("The New York Public Library", library.name)
+        eq_("1236662b-66cf-3068-af58-95385f299b4f", library.urn)
+        eq_("https://nypl.org/", library.web_url)
+        eq_("https://circulation.librarysimplified.org/", library.opds_url)
+        eq_("Serving the five boroughs of New York, NY.", library.description)
+
+        [alias] = library.aliases
+        eq_("NYPL", alias.name)
+        eq_("eng", alias.language)
+
+        eq_([nyc], [x.place for x in library.service_areas])
 

--- a/tests/test_scripts.py
+++ b/tests/test_scripts.py
@@ -11,6 +11,7 @@ from model import (
 from scripts import (
     AddLibraryScript,
     LoadPlacesScript,
+    SearchLibraryScript,
     SearchPlacesScript,
 )
 from . import (
@@ -86,4 +87,26 @@ class TestAddLibraryScript(DatabaseTest):
         eq_("eng", alias.language)
 
         eq_([nyc], [x.place for x in library.service_areas])
+
+
+class TestSearchPlacesScript(DatabaseTest):
+
+    def test_run(self):
+        nys = self.new_york_state
+        nypl = self.nypl
+        csl = self.connecticut_state_library
+        zip = self.zip_10018
+        ct = self.connecticut_state
+        nyc = self.new_york_city
+        nypl.opds_url = "http://opds/"
+        
+        # Run the script...
+        output = StringIO()
+        script = SearchLibraryScript(self._db)
+        script.run(cmd_args=["10018"], stdout=output)
+
+        # We found the library whose service area overlaps 10018
+        # (NYPL), but not the other library.
+        actual_output = output.getvalue()
+        eq_("%s: %s\n" % (nypl.name, nypl.opds_url), actual_output)
 

--- a/tests/test_scripts.py
+++ b/tests/test_scripts.py
@@ -89,7 +89,7 @@ class TestAddLibraryScript(DatabaseTest):
         eq_([nyc], [x.place for x in library.service_areas])
 
 
-class TestSearchPlacesScript(DatabaseTest):
+class TestSearchLibraryScript(DatabaseTest):
 
     def test_run(self):
         nys = self.new_york_state


### PR DESCRIPTION
This branch creates three useful command-line scripts:

1. `search_places` lets you search for places by name and find their `external_id`s.
2. `add_library` lets you create a `Library` object and associate a number of `external_id`s with its service area.
3. `search` is a command-line interface to the library search algorithm.

With these three scripts along with `load_places`, I was able to verify that the search algorithm performs reasonably well in a dev environment that includes one library and every place in the United States. I created a library representing NYPL and was able to quickly check whether or not a query ("10018", "Kew Gardens", "Brooklyn", "Kings", "New York") matched a place name inside NYPL's service area.