### PR TITLE
Copy adobe vendor ID code

### DIFF
--- a/adobe_vendor_id.py
+++ b/adobe_vendor_id.py
@@ -1,0 +1,160 @@
+from nose.tools import set_trace
+import logging
+import uuid
+import base64
+import os
+import datetime
+import jwt
+from jwt.algorithms import HMACAlgorithm
+
+import flask
+from flask import Response
+from flask.ext.babel import lazy_gettext as _
+from config import (
+    CannotLoadConfiguration,
+    Configuration,
+)
+from sqlalchemy.orm.session import Session
+from util.xmlparser import XMLParser
+from util.problem_detail import ProblemDetail
+
+class AdobeRequestParser(XMLParser):
+
+    NAMESPACES = { "adept" : "http://ns.adobe.com/adept" }
+
+    def process(self, data):
+        requests = list(self.process_all(
+            data, self.REQUEST_XPATH, self.NAMESPACES))
+        if not requests:
+            return None
+        # There should only be one request tag, but if there's more than
+        # one, only return the first one.
+        return requests[0]
+
+    def _add(self, d, tag, key, namespaces, transform=None):
+        v = self._xpath1(tag, 'adept:' + key, namespaces)
+        if v is not None:
+            v = v.text
+            if v is not None:
+                v = v.strip()
+                if transform is not None:
+                    v = transform(v)
+        d[key] = v
+
+
+class AdobeSignInRequestParser(AdobeRequestParser):
+
+    REQUEST_XPATH = "/adept:signInRequest"
+
+    STANDARD = 'standard'
+    AUTH_DATA = 'authData'
+
+    def process_one(self, tag, namespaces):
+        method = tag.attrib.get('method')
+
+        if not method:
+            raise ValueError("No signin method specified")
+        data = dict(method=method)
+        if method == self.STANDARD:
+            self._add(data, tag, 'username', namespaces)
+            self._add(data, tag, 'password', namespaces)
+        elif method == self.AUTH_DATA:
+            self._add(data, tag, self.AUTH_DATA, namespaces, base64.b64decode)
+        else:
+            raise ValueError("Unknown signin method: %s" % method)
+        return data
+
+
+class AdobeAccountInfoRequestParser(AdobeRequestParser):
+
+    REQUEST_XPATH = "/adept:accountInfoRequest"
+
+    def process_one(self, tag, namespaces):
+        method = tag.attrib.get('method')
+        data = dict(method=method)
+        self._add(data, tag, 'user', namespaces)
+        return data
+
+
+class AdobeVendorIDRequestHandler(object):
+
+    """Standalone class that can be tested without bringing in Flask or
+    the database schema.
+    """
+
+    SIGN_IN_RESPONSE_TEMPLATE = """<signInResponse xmlns="http://ns.adobe.com/adept">
+<user>%(user)s</user>
+<label>%(label)s</label>
+</signInResponse>"""
+
+    ACCOUNT_INFO_RESPONSE_TEMPLATE = """<accountInfoResponse xmlns="http://ns.adobe.com/adept">
+<label>%(label)s</label>
+</accountInfoResponse>"""
+
+    AUTH_ERROR_TYPE = "AUTH"
+    ACCOUNT_INFO_ERROR_TYPE = "ACCOUNT_INFO"   
+
+    ERROR_RESPONSE_TEMPLATE = '<error xmlns="http://ns.adobe.com/adept" data="E_%(vendor_id)s_%(type)s %(message)s"/>'
+
+    TOKEN_FAILURE = 'Incorrect token.'
+    AUTHENTICATION_FAILURE = 'Incorrect barcode or PIN.'
+    URN_LOOKUP_FAILURE = "Could not identify patron from '%s'."
+
+    def __init__(self, vendor_id):
+        self.vendor_id = vendor_id
+
+    def handle_signin_request(self, data, standard_lookup, authdata_lookup):
+        parser = AdobeSignInRequestParser()
+        try:
+            data = parser.process(data)
+        except Exception, e:
+            return self.error_document(self.AUTH_ERROR_TYPE, str(e))
+        user_id = label = None
+        if not data:
+            return self.error_document(
+                self.AUTH_ERROR_TYPE, "Request document in wrong format.")
+        if not 'method' in data:
+            return self.error_document(
+                self.AUTH_ERROR_TYPE, "No method specified")
+        if data['method'] == parser.STANDARD:
+            user_id, label = standard_lookup(data)
+            failure = self.AUTHENTICATION_FAILURE
+        elif data['method'] == parser.AUTH_DATA:
+            authdata = data[parser.AUTH_DATA]
+            user_id, label = authdata_lookup(authdata)
+            failure = self.TOKEN_FAILURE
+        if user_id is None:
+            return self.error_document(self.AUTH_ERROR_TYPE, failure)
+        else:
+            return self.SIGN_IN_RESPONSE_TEMPLATE % dict(
+                user=user_id, label=label)
+
+    def handle_accountinfo_request(self, data, urn_to_label):
+        parser = AdobeAccountInfoRequestParser()
+        label = None
+        try:
+            data = parser.process(data)
+            if not data:
+                return self.error_document(
+                    self.ACCOUNT_INFO_ERROR_TYPE,
+                    "Request document in wrong format.")
+            if not 'user' in data:
+                return self.error_document(
+                    self.ACCOUNT_INFO_ERROR_TYPE,
+                    "Could not find user identifer in request document.")
+            label = urn_to_label(data['user'])
+        except Exception, e:
+            return self.error_document(
+                self.ACCOUNT_INFO_ERROR_TYPE, str(e))
+
+        if label:
+            return self.ACCOUNT_INFO_RESPONSE_TEMPLATE % dict(label=label)
+        else:
+            return self.error_document(
+                self.ACCOUNT_INFO_ERROR_TYPE,
+                self.URN_LOOKUP_FAILURE % data['user']
+            )
+
+    def error_document(self, type, message):
+        return self.ERROR_RESPONSE_TEMPLATE % dict(
+            vendor_id=self.vendor_id, type=type, message=message)

--- a/adobe_vendor_id.py
+++ b/adobe_vendor_id.py
@@ -1,22 +1,7 @@
 from nose.tools import set_trace
-import logging
-import uuid
 import base64
-import os
-import datetime
-import jwt
-from jwt.algorithms import HMACAlgorithm
 
-import flask
-from flask import Response
-from flask.ext.babel import lazy_gettext as _
-from config import (
-    CannotLoadConfiguration,
-    Configuration,
-)
-from sqlalchemy.orm.session import Session
 from util.xmlparser import XMLParser
-from util.problem_detail import ProblemDetail
 
 class AdobeRequestParser(XMLParser):
 

--- a/config.py
+++ b/config.py
@@ -132,7 +132,7 @@ class Configuration(object):
             return None, None
         return (
             integration[cls.ADOBE_VENDOR_ID],
-            integration[cls.ADOBE_NODE_VALUE],
+            integration[cls.ADOBE_VENDOR_ID_NODE_VALUE],
         )
     
     @classmethod

--- a/config.py
+++ b/config.py
@@ -1,6 +1,22 @@
+import contextlib
+import copy
 import json
 import os
 import logging
+
+@contextlib.contextmanager
+def temp_config(new_config=None, replacement_classes=None):
+    old_config = Configuration.instance
+    replacement_classes = replacement_classes or [Configuration]
+    if new_config is None:
+        new_config = copy.deepcopy(old_config)
+    try:
+        for c in replacement_classes:
+            c.instance = new_config
+        yield new_config
+    finally:
+        for c in replacement_classes:
+            c.instance = old_config
 
 class CannotLoadConfiguration(Exception):
     pass
@@ -26,6 +42,10 @@ class Configuration(object):
     DATABASE_PRODUCTION_URL = "production_url"
     DATABASE_TEST_URL = "test_url"
 
+    ADOBE_VENDOR_ID_INTEGRATION = "Adobe Vendor ID"
+    ADOBE_VENDOR_ID = "vendor_id"
+    ADOBE_VENDOR_ID_NODE_VALUE = "node_value"
+    
     @classmethod
     def load(cls):
         cfv = 'SIMPLIFIED_CONFIGURATION_FILE'
@@ -100,6 +120,21 @@ class Configuration(object):
             key = cls.DATABASE_PRODUCTION_URL
         return cls.integration(cls.DATABASE_INTEGRATION)[key]
 
+    @classmethod
+    def vendor_id(cls):
+        """Look up the Adobe Vendor ID configuration for this registry.
+
+        :return: a 2-tuple (vendor ID, node value)
+        """
+        integration = cls.integration(cls.ADOBE_VENDOR_ID_INTEGRATION,
+                                      required=False)
+        if not integration:
+            return None, None
+        return (
+            integration[cls.ADOBE_VENDOR_ID],
+            integration[cls.ADOBE_NODE_VALUE],
+        )
+    
     @classmethod
     def logging_policy(cls):
         default_logging = {}

--- a/model.py
+++ b/model.py
@@ -166,6 +166,7 @@ def create(db, model, create_method='',
     
 Base = declarative_base()
 
+    
 class Library(Base):
     """An entry in this table corresponds more or less to an OPDS server.
 

--- a/tests/test_adobe_vendor_id.py
+++ b/tests/test_adobe_vendor_id.py
@@ -1,0 +1,184 @@
+import base64
+from nose.tools import (
+    eq_,
+    set_trace,
+)
+import contextlib
+from config import (
+    CannotLoadConfiguration,
+    Configuration,
+    temp_config,
+)
+
+from adobe_vendor_id import (
+    AdobeSignInRequestParser,
+    AdobeAccountInfoRequestParser,
+    AdobeVendorIDRequestHandler,
+)
+
+from . import (
+    DatabaseTest,
+)
+
+class VendorIDTest(DatabaseTest):
+       
+    @contextlib.contextmanager
+    def temp_config(self):
+        """Configure a basic Vendor ID Service setup."""
+        name = Configuration.ADOBE_VENDOR_ID_INTEGRATION
+        with temp_config() as config:
+            config[Configuration.INTEGRATIONS][name] = {
+                Configuration.ADOBE_VENDOR_ID: "VENDORID",
+                Configuration.ADOBE_NODE_VALUE: 114740953091845,
+            }
+            yield config
+
+
+class TestVendorIDRequestParsers(object):
+
+    username_sign_in_request = """<signInRequest method="standard" xmlns="http://ns.adobe.com/adept">
+<username>Vendor username</username>
+<password>Vendor password</password>
+</signInRequest>"""
+
+    authdata_sign_in_request = """<signInRequest method="authData" xmlns="http://ns.adobe.com/adept">
+<authData> dGhpcyBkYXRhIHdhcyBiYXNlNjQgZW5jb2RlZA== </authData>
+</signInRequest>"""
+
+    accountinfo_request = """<accountInfoRequest method="standard" xmlns="http://ns.adobe.com/adept">
+<user>urn:uuid:0xxxxxxx-xxxx-1xxx-xxxx-yyyyyyyyyyyy</user>
+</accountInfoRequest >"""
+
+    def test_username_sign_in_request(self):
+        parser = AdobeSignInRequestParser()
+        data = parser.process(self.username_sign_in_request)
+        eq_({'username': 'Vendor username',
+             'password': 'Vendor password', 'method': 'standard'}, data)
+
+    def test_authdata_sign_in_request(self):
+        parser = AdobeSignInRequestParser()
+        data = parser.process(self.authdata_sign_in_request)
+        eq_({'authData': 'this data was base64 encoded', 'method': 'authData'},
+            data)
+
+    def test_accountinfo_request(self):
+        parser = AdobeAccountInfoRequestParser()
+        data = parser.process(self.accountinfo_request)
+        eq_({'method': 'standard', 
+             'user': 'urn:uuid:0xxxxxxx-xxxx-1xxx-xxxx-yyyyyyyyyyyy'},
+            data)
+
+class TestVendorIDRequestHandler(object):
+
+    username_sign_in_request = """<signInRequest method="standard" xmlns="http://ns.adobe.com/adept">
+<username>%(username)s</username>
+<password>%(password)s</password>
+</signInRequest>"""
+
+    authdata_sign_in_request = """<signInRequest method="authData" xmlns="http://ns.adobe.com/adept">
+<authData>%(authdata)s</authData>
+</signInRequest>"""
+
+    accountinfo_request = """<accountInfoRequest method="standard" xmlns="http://ns.adobe.com/adept">
+<user>%(uuid)s</user>
+</accountInfoRequest >"""
+
+    TEST_VENDOR_ID = "1045"
+
+    user1_uuid = "test-uuid"
+    user1_label = "Human-readable label for user1"
+    username_password_lookup = {
+        ("user1", "pass1") : (user1_uuid, user1_label)
+    }
+
+    authdata_lookup = {
+        "The secret token" : (user1_uuid, user1_label)
+    }
+
+    userinfo_lookup = { user1_uuid : user1_label }
+
+    @property
+    def _handler(self):
+        return AdobeVendorIDRequestHandler(
+            self.TEST_VENDOR_ID)
+
+    @classmethod
+    def _standard_login(cls, data):
+        return cls.username_password_lookup.get(
+            (data.get('username'), data.get('password')), (None, None))
+
+    @classmethod
+    def _authdata_login(cls, authdata):
+        return cls.authdata_lookup.get(authdata, (None, None))
+
+    @classmethod
+    def _userinfo(cls, uuid):
+        return cls.userinfo_lookup.get(uuid)
+
+    def test_error_document(self):
+        doc = self._handler.error_document(
+            "VENDORID", "Some random error")
+        eq_('<error xmlns="http://ns.adobe.com/adept" data="E_1045_VENDORID Some random error"/>', doc)
+
+    def test_handle_username_sign_in_request_success(self):
+        doc = self.username_sign_in_request % dict(
+            username="user1", password="pass1")
+        result = self._handler.handle_signin_request(
+            doc, self._standard_login, self._authdata_login)
+        assert result.startswith('<signInResponse xmlns="http://ns.adobe.com/adept">\n<user>test-uuid</user>\n<label>Human-readable label for user1</label>\n</signInResponse>')
+
+    def test_handle_username_sign_in_request_failure(self):
+        doc = self.username_sign_in_request % dict(
+            username="user1", password="wrongpass")
+        result = self._handler.handle_signin_request(
+            doc, self._standard_login, self._authdata_login)
+        eq_('<error xmlns="http://ns.adobe.com/adept" data="E_1045_AUTH Incorrect barcode or PIN."/>', result)
+
+    def test_handle_username_authdata_request_success(self):
+        doc = self.authdata_sign_in_request % dict(
+            authdata=base64.b64encode("The secret token"))
+        result = self._handler.handle_signin_request(
+            doc, self._standard_login, self._authdata_login)
+        assert result.startswith('<signInResponse xmlns="http://ns.adobe.com/adept">\n<user>test-uuid</user>\n<label>Human-readable label for user1</label>\n</signInResponse>')
+
+    def test_handle_username_authdata_request_invalid(self):
+        doc = self.authdata_sign_in_request % dict(
+            authdata="incorrect")
+        result = self._handler.handle_signin_request(
+            doc, self._standard_login, self._authdata_login)
+        assert result.startswith('<error xmlns="http://ns.adobe.com/adept" data="E_1045_AUTH')
+
+    def test_handle_username_authdata_request_failure(self):
+        doc = self.authdata_sign_in_request % dict(
+            authdata=base64.b64encode("incorrect"))
+        result = self._handler.handle_signin_request(
+            doc, self._standard_login, self._authdata_login)
+        eq_('<error xmlns="http://ns.adobe.com/adept" data="E_1045_AUTH Incorrect token."/>', result)
+
+    def test_failure_send_login_request_to_accountinfo(self):
+        doc = self.authdata_sign_in_request % dict(
+            authdata=base64.b64encode("incorrect"))
+        result = self._handler.handle_accountinfo_request(
+            doc, self._userinfo)
+        eq_('<error xmlns="http://ns.adobe.com/adept" data="E_1045_ACCOUNT_INFO Request document in wrong format."/>', result)
+
+    def test_failure_send_accountinfo_request_to_login(self):
+        doc = self.accountinfo_request % dict(
+            uuid=self.user1_uuid)
+        result = self._handler.handle_signin_request(
+            doc, self._standard_login, self._authdata_login)
+        eq_('<error xmlns="http://ns.adobe.com/adept" data="E_1045_AUTH Request document in wrong format."/>', result)
+
+    def test_handle_accountinfo_success(self):
+        doc = self.accountinfo_request % dict(
+            uuid=self.user1_uuid)
+        result = self._handler.handle_accountinfo_request(
+            doc, self._userinfo)
+        eq_('<accountInfoResponse xmlns="http://ns.adobe.com/adept">\n<label>Human-readable label for user1</label>\n</accountInfoResponse>', result)
+
+    def test_handle_accountinfo_failure(self):
+        doc = self.accountinfo_request % dict(
+            uuid="not the uuid")
+        result = self._handler.handle_accountinfo_request(
+            doc, self._userinfo)
+        eq_('<error xmlns="http://ns.adobe.com/adept" data="E_1045_ACCOUNT_INFO Could not identify patron from \'not the uuid\'."/>', result)

--- a/tests/test_adobe_vendor_id.py
+++ b/tests/test_adobe_vendor_id.py
@@ -29,11 +29,28 @@ class VendorIDTest(DatabaseTest):
         with temp_config() as config:
             config[Configuration.INTEGRATIONS][name] = {
                 Configuration.ADOBE_VENDOR_ID: "VENDORID",
-                Configuration.ADOBE_NODE_VALUE: 114740953091845,
+                Configuration.ADOBE_VENDOR_ID_NODE_VALUE: 114740953091845,
             }
             yield config
 
+class TestConfiguration(VendorIDTest):
 
+    def test_accessor(self):
+        with self.temp_config() as config:
+            vendor_id, node_value = Configuration.vendor_id()
+            eq_("VENDORID", vendor_id)
+            eq_(114740953091845, node_value)
+
+    def test_accessor_vendor_id_not_configured(self):
+        with self.temp_config() as config:
+            del config[Configuration.INTEGRATIONS][
+                Configuration.ADOBE_VENDOR_ID_INTEGRATION
+            ]
+            vendor_id, node_value = Configuration.vendor_id()
+            eq_(None, vendor_id)
+            eq_(None, node_value)
+
+    
 class TestVendorIDRequestParsers(object):
 
     username_sign_in_request = """<signInRequest method="standard" xmlns="http://ns.adobe.com/adept">

--- a/util/xmlparser.py
+++ b/util/xmlparser.py
@@ -1,0 +1,64 @@
+from nose.tools import set_trace
+from lxml import etree
+from StringIO import StringIO
+
+class XMLParser(object):
+
+    """Helper functions to process XML data."""
+
+    NAMESPACES = {}
+
+    @classmethod
+    def _xpath(cls, tag, expression, namespaces=None):
+        if not namespaces:
+            namespaces = cls.NAMESPACES
+        """Wrapper to do a namespaced XPath expression."""
+        return tag.xpath(expression, namespaces=namespaces)
+
+    @classmethod
+    def _xpath1(cls, tag, expression, namespaces=None):
+        """Wrapper to do a namespaced XPath expression."""
+        values = cls._xpath(tag, expression, namespaces=namespaces)
+        if not values:
+            return None
+        return values[0]
+
+    def _cls(self, tag_name, class_name):
+        """Return an XPath expression that will find a tag with the given CSS class."""
+        return 'descendant-or-self::node()/%s[contains(concat(" ", normalize-space(@class), " "), " %s ")]' % (tag_name, class_name)
+
+    def text_of_optional_subtag(self, tag, name, namespaces=None):
+        tag = self._xpath1(tag, name, namespaces=namespaces)
+        if tag is None or tag.text is None:
+            return None
+        else:
+            return unicode(tag.text)
+      
+    def text_of_subtag(self, tag, name, namespaces=None):
+        return unicode(tag.xpath(name, namespaces=namespaces)[0].text)
+
+    def int_of_subtag(self, tag, name, namespaces=None):
+        return int(self.text_of_subtag(tag, name, namespaces=namespaces))
+
+    def int_of_optional_subtag(self, tag, name, namespaces=None):
+        v = self.text_of_optional_subtag(tag, name, namespaces=namespaces)
+        if not v:
+            return v
+        return int(v)
+
+    def process_all(self, xml, xpath, namespaces=None, handler=None, parser=None):
+        if not parser:
+            parser = etree.XMLParser()
+        if not handler:
+            handler = self.process_one
+        if isinstance(xml, basestring):
+            root = etree.parse(StringIO(xml), parser)
+        else:
+            root = xml
+        for i in root.xpath(xpath, namespaces=namespaces):
+            data = handler(i, namespaces)
+            if data:
+                yield data
+
+    def process_one(self, tag, namespaces):
+        return None


### PR DESCRIPTION
This branch copies all the remaining Adobe vendor ID code that can be copied in from circulation without modification. This includes the code that parses incoming requests, handles the abstract logic of the Vendor ID spec, and generates responses.

It does not include any code that interacts with the data model or the web application -- that code needs to be ported to the new model/application and simplified, and I'll handle it in the next branch.

One bit of code has been modified: the code that gathers Configuration values for the vendor ID implementation. There's almost no code now that most of the configuration information is kept in `Library` objects; all we need to keep track of now are two scalar values: the vendor ID itself and the node value.