### PR TITLE
If the request was forwarded, use the originating IP instead of the IP of the forwarding machine.

### DIFF
--- a/app.py
+++ b/app.py
@@ -10,6 +10,7 @@ from config import Configuration
 from controller import LibraryRegistry
 from model import SessionManager
 from util.problem_detail import ProblemDetail
+from util.flask_util import originating_ip
 from util.app_server import returns_problem_detail
 
 app = Flask(__name__)
@@ -46,19 +47,19 @@ def shutdown_session(exception):
         else:
             app.library_registry._db.commit()
 
-
+       
 @app.route('/')
 @returns_problem_detail
 def nearby():
     return app.library_registry.registry_controller.nearby(
-        request.remote_addr
+        originating_ip()
     )
 
 @app.route('/search')
 @returns_problem_detail
 def search():
     return app.library_registry.registry_controller.search(
-        request.remote_addr
+        originating_ip()
     )
 
 @app.route('/heartbeat')

--- a/util/flask_util.py
+++ b/util/flask_util.py
@@ -22,3 +22,16 @@ def problem(type, status, title, detail=None, instance=None, headers={}):
     
 def languages_for_request():
     return languages_from_accept(flask.request.accept_languages)
+
+def originating_ip():
+    """If there is an X-Forwarded-For header, use its value as the
+    originating IP address. Otherwise, use the address that originated
+    this request.
+    """
+    address = None
+    header = 'X-Forwarded-For'
+    if header in flask.request.headers:
+        address = flask.request.headers[header]
+    if not address:
+        address = flask.request.remote_addr
+    return address


### PR DESCRIPTION
This branch solves the problem we see on a library registry deployed behind a load balancer, where geolocation fails because we look at the load balancer's IP instead of the patron's IP.

As a bonus, this makes it possible to test geolocation locally, by passing in X-Forwarded-For with the IP you want to test.