### PR TITLE
Fix duplicate libraries from showing up in other contexts

### DIFF
--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -248,7 +248,7 @@ class TestLibrary(DatabaseTest):
 
         # The Brooklyn Public Library serves New York City.
         brooklyn = self._library(
-            "Brooklyn Public Library", [self.new_york_city]
+            "Brooklyn Public Library", [self.new_york_city, self.zip_11212]
         )
 
         # We can find the library by its name.


### PR DESCRIPTION
I landed my previous branch prematurely. The same problem that caused duplicate entries in `Library.nearby()` was present in the other two `Library` search methods. This branch fixes those methods in the same way, and modifies a test to make sure the problem will break tests if it recurs.