### PR TITLE
Delegate unrecognized authentication attempts to another Vendor ID server

### DIFF
--- a/adobe_vendor_id.py
+++ b/adobe_vendor_id.py
@@ -236,7 +236,7 @@ class AdobeVendorIDModel(object):
                     pass
 
         # Neither this server nor the delegates were able to do anything.
-        return None
+        return None, None
             
     def authdata_lookup(self, authdata):
         """Treat an authdata string as a short client token. Return an Adobe
@@ -265,7 +265,7 @@ class AdobeVendorIDModel(object):
                     pass
 
         # Neither this server nor the delegates were able to do anything.
-        return None
+        return None, None
 
     def account_id_and_label(self, delegated_patron_identifier):
         "Turn a DelegatedPatronIdentifier into a (account id, label) 2-tuple."
@@ -355,7 +355,7 @@ class AdobeVendorIDClient(object):
         self.handle_error(response.status_code, content)
         label = self.extract_label(content)
         if not label:
-            raise VendorIDException("Unexpected response: %s" % content)
+            raise VendorIDServerException("Unexpected response: %s" % content)
         return label, content
         
     def extract_user_identifier(self, content):
@@ -366,8 +366,8 @@ class AdobeVendorIDClient(object):
    
     def handle_error(self, status_code, content):
         if status_code != 200:
-            raise VendorIDException(
-                "Unexpected status code: %s" % status_Code
+            raise VendorIDServerException(
+                "Unexpected status code: %s" % status_code
             )
         error = self._extract_by_re(content, self.ERROR_RE)
         if error:
@@ -385,7 +385,7 @@ class AdobeVendorIDClient(object):
         identifier = self.extract_user_identifier(content)
         label = self.extract_label(content)
         if not identifier or not label:
-            raise VendorIDException("Unexpected response: %s" % content)
+            raise VendorIDServerException("Unexpected response: %s" % content)
         return identifier, label, content
 
 

--- a/adobe_vendor_id.py
+++ b/adobe_vendor_id.py
@@ -257,7 +257,7 @@ class AdobeVendorIDModel(object):
             for delegate in self.delegates:
                 try:
                     account_id, label, content = delegate.sign_in_authdata(
-                        username, password
+                        authdata
                     )
                     return account_id, label
                 except Exception, e:
@@ -395,7 +395,7 @@ class MockAdobeVendorIDClient(AdobeVendorIDClient):
     def __init__(self):
         self.queue = []
 
-    def queue(self, response):
+    def enqueue(self, response):
         """Queue a response."""
         self.queue.insert(0, response)
         
@@ -404,6 +404,8 @@ class MockAdobeVendorIDClient(AdobeVendorIDClient):
 
         If it's an exception, raise it. Otherwise return it.
         """
+        if not self.queue:
+            raise VendorIDServerException("No response queued.")
         response = self.queue.pop()
         if isinstance(response, Exception):
             raise response

--- a/config.py
+++ b/config.py
@@ -45,6 +45,7 @@ class Configuration(object):
     ADOBE_VENDOR_ID_INTEGRATION = "Adobe Vendor ID"
     ADOBE_VENDOR_ID = "vendor_id"
     ADOBE_VENDOR_ID_NODE_VALUE = "node_value"
+    ADOBE_VENDOR_ID_DELEGATE_URL = "delegate_url"
     
     @classmethod
     def load(cls):
@@ -124,15 +125,20 @@ class Configuration(object):
     def vendor_id(cls):
         """Look up the Adobe Vendor ID configuration for this registry.
 
-        :return: a 2-tuple (vendor ID, node value)
+        :return: a 3-tuple (vendor ID, node value, [delegates])
         """
         integration = cls.integration(cls.ADOBE_VENDOR_ID_INTEGRATION,
                                       required=False)
         if not integration:
             return None, None
+        delegates = []
+        delegate_url = integration.get(cls.ADOBE_VENDOR_ID_DELEGATE_URL)
+        if delegate_url:
+            delegates.append(delegate_url)
         return (
             integration[cls.ADOBE_VENDOR_ID],
             integration[cls.ADOBE_VENDOR_ID_NODE_VALUE],
+            delegates
         )
     
     @classmethod

--- a/config.py
+++ b/config.py
@@ -130,7 +130,7 @@ class Configuration(object):
         integration = cls.integration(cls.ADOBE_VENDOR_ID_INTEGRATION,
                                       required=False)
         if not integration:
-            return None, None
+            return None, None, []
         delegates = []
         delegate_url = integration.get(cls.ADOBE_VENDOR_ID_DELEGATE_URL)
         if delegate_url:

--- a/controller.py
+++ b/controller.py
@@ -57,7 +57,7 @@ class LibraryRegistry(object):
         vendor_id, node_value = Configuration.vendor_id()
         if vendor_id:
             self.adobe_vendor_id = AdobeVendorIDController(
-                self._db, vendor_id, node_value
+                self._db, vendor_id, node_value, None
             )
         else:
             self.adobe_vendor_id = None

--- a/controller.py
+++ b/controller.py
@@ -54,10 +54,10 @@ class LibraryRegistry(object):
         """Set up all the controllers that will be used by the web app."""
         self.registry_controller = LibraryRegistryController(self)
         self.heartbeat = HeartbeatController()
-        vendor_id, node_value = Configuration.vendor_id()
+        vendor_id, node_value, delegates = Configuration.vendor_id()
         if vendor_id:
             self.adobe_vendor_id = AdobeVendorIDController(
-                self._db, vendor_id, node_value, None
+                self._db, vendor_id, node_value, delegates
             )
         else:
             self.adobe_vendor_id = None

--- a/scripts.py
+++ b/scripts.py
@@ -245,45 +245,28 @@ class AdobeVendorIDAcceptanceTestScript(Script):
         
         print "1. Checking status: %s" % client.status_url
         response = client.status()
-        if response is True:
-            print 'OK Service is up and running.'
-        else:
-            print "XX Got unexpected response: %r" % response.content
-        print
+        # status() will raise an exception if anything is wrong.
+        print 'OK Service is up and running.'
             
         print "2. Passing token into SignIn as authdata: %s" % client.signin_url
-        response = client.sign_in_authdata(token)
-        if isinstance(response, tuple):
-            identifier, label, content = response
-            print "OK Found user identifier and label."
-            print "   User identifier: %s" % identifier
-            print "   Label: %s" % label
-            print "   Full content: %s" % content
-        else:
-            print "XX Got unexpected response: %r" % response.content
+        identifier, label, content = client.sign_in_authdata(token)
+        print "OK Found user identifier and label."
+        print "   User identifier: %s" % identifier
+        print "   Label: %s" % label
+        print "   Full content: %s" % content
 
         print
         print "3. Passing token into SignIn as username/password."
         username, password = token.rsplit('|', 1)
-        response = client.sign_in_standard(username, password)
-        if isinstance(response, tuple):
-            identifier, label, content = response
-            print "OK Found user identifier and label."
-            print "   User identifier: %s" % identifier
-            print "   Label: %s" % label
-            print "   Full content: %s" % content
-        else:
-            print "XX Got unexpected response: %r" % response.content
-            identifier = None
+        identifier, label, content = client.sign_in_standard(username, password)
+        print "OK Found user identifier and label."
+        print "   User identifier: %s" % identifier
+        print "   Label: %s" % label
+        print "   Full content: %s" % content
             
-        if identifier:
-            print
-            print "4. Passing identifier into UserInfo to get user info: %s" % client.accountinfo_url
-            response = client.user_info(identifier)
-            if isinstance(response, tuple):
-                user_info, content = response
-                print "OK Found user info: %s" % user_info
-                print "   Full content: %s" % content
-            else:
-                print "XX Got unexpected response: %r" % response.content
+        print
+        print "4. Passing identifier into UserInfo to get user info: %s" % client.accountinfo_url
+        user_info, content = client.user_info(identifier)
+        print "OK Found user info: %s" % user_info
+        print "   Full content: %s" % content
 

--- a/tests/test_adobe_vendor_id.py
+++ b/tests/test_adobe_vendor_id.py
@@ -313,7 +313,7 @@ class TestVendorIDModel(VendorIDTest):
         
         # We tried delegate 1 before getting the answer from delegate 2.
         eq_([], delegate1.queue)
-        eq_([], delegate1.queue)
+        eq_([], delegate2.queue)
 
         # Now test authentication by authdata.
 

--- a/tests/test_adobe_vendor_id.py
+++ b/tests/test_adobe_vendor_id.py
@@ -46,18 +46,20 @@ class TestConfiguration(VendorIDTest):
 
     def test_accessor(self):
         with self.temp_config() as config:
-            vendor_id, node_value = Configuration.vendor_id()
+            vendor_id, node_value, delegates = Configuration.vendor_id()
             eq_("VENDORID", vendor_id)
             eq_(114740953091845, node_value)
-
+            eq_([], delegates)
+            
     def test_accessor_vendor_id_not_configured(self):
         with self.temp_config() as config:
             del config[Configuration.INTEGRATIONS][
                 Configuration.ADOBE_VENDOR_ID_INTEGRATION
             ]
-            vendor_id, node_value = Configuration.vendor_id()
+            vendor_id, node_value, delegates = Configuration.vendor_id()
             eq_(None, vendor_id)
             eq_(None, node_value)
+            eq_([], delegates)
 
     
 class TestVendorIDRequestParsers(object):
@@ -215,8 +217,8 @@ class TestVendorIDModel(VendorIDTest):
     def setup(self):
         super(TestVendorIDModel, self).setup()
         with self.temp_config() as config:
-            vendor_id, node_value = Configuration.vendor_id()
-            self.model = AdobeVendorIDModel(self._db, node_value)
+            vendor_id, node_value, delegates = Configuration.vendor_id()
+            self.model = AdobeVendorIDModel(self._db, node_value, delegates)
 
         # Here's a library that participates in the registry.
         self.library = self._library()
@@ -285,3 +287,9 @@ class TestVendorIDModel(VendorIDTest):
         )
         eq_(None, None, (self.model.authdata_lookup, bad_signature))
 
+
+    def test_delegation(self):
+        """A model that doesn't know how to handle something can delegate
+        to another Vendor ID server.
+        """
+        


### PR DESCRIPTION
This branch makes it possible for a library registry to take any standard or authdata credentials it doesn't understand and ask another Vendor ID server to validate them. This gives us a migration path for moving from another Vendor ID server to the library registry.