### PR TITLE
Brought over ExternalIntegration and ConfigurationSetting from server_core.

### DIFF
--- a/app.py
+++ b/app.py
@@ -8,7 +8,7 @@ from flask_sqlalchemy_session import flask_scoped_session
 
 from config import Configuration
 from controller import LibraryRegistry
-from model import SessionManager
+from model import SessionManager, ConfigurationSetting
 from util.problem_detail import ProblemDetail
 from util.flask_util import originating_ip
 from util.app_server import returns_problem_detail
@@ -94,8 +94,7 @@ def adobe_vendor_id_status():
 
 if __name__ == '__main__':
     debug = True
-    url = Configuration.integration_url(
-        Configuration.LIBRARY_REGISTRY_INTEGRATION, required=True)
+    url = ConfigurationSetting.sitewide(_db, Configuration.BASE_URL).value
     scheme, netloc, path, parameters, query, fragment = urlparse.urlparse(url)
     if ':' in netloc:
         host, port = netloc.split(':')

--- a/bin/configuration/configure_integration
+++ b/bin/configuration/configure_integration
@@ -1,0 +1,11 @@
+#!/usr/bin/env python
+"""Configure an integration's settings."""
+import os
+import sys
+bin_dir = os.path.split(__file__)[0]
+package_dir = os.path.join(bin_dir, "..", "..")
+sys.path.append(os.path.abspath(package_dir))
+from scripts import (
+     ConfigureIntegrationScript
+)
+ConfigureIntegrationScript().run()

--- a/bin/configuration/configure_site_setting
+++ b/bin/configuration/configure_site_setting
@@ -1,0 +1,11 @@
+#!/usr/bin/env python
+"""View or configure the site-wide settings."""
+import os
+import sys
+bin_dir = os.path.split(__file__)[0]
+package_dir = os.path.join(bin_dir, "..", "..")
+sys.path.append(os.path.abspath(package_dir))
+from scripts import (
+     ConfigureSiteScript
+)
+ConfigureSiteScript().run()

--- a/bin/configuration/show_integrations
+++ b/bin/configuration/show_integrations
@@ -1,0 +1,11 @@
+#!/usr/bin/env python
+"""Show an integration or the full list of integrations."""
+import os
+import sys
+bin_dir = os.path.split(__file__)[0]
+package_dir = os.path.join(bin_dir, "..", "..")
+sys.path.append(os.path.abspath(package_dir))
+from scripts import (
+     ShowIntegrationsScript
+)
+ShowIntegrationsScript().run()

--- a/controller.py
+++ b/controller.py
@@ -54,7 +54,7 @@ class LibraryRegistry(object):
         """Set up all the controllers that will be used by the web app."""
         self.registry_controller = LibraryRegistryController(self)
         self.heartbeat = HeartbeatController()
-        vendor_id, node_value, delegates = Configuration.vendor_id()
+        vendor_id, node_value, delegates = Configuration.vendor_id(self._db)
         if vendor_id:
             self.adobe_vendor_id = AdobeVendorIDController(
                 self._db, vendor_id, node_value, delegates

--- a/model.py
+++ b/model.py
@@ -4,6 +4,7 @@ import datetime
 import logging
 from nose.tools import set_trace
 import re
+import json
 import uuid
 import warnings
 from psycopg2.extensions import adapt as sqlescape
@@ -43,6 +44,7 @@ from sqlalchemy.orm.exc import (
 from sqlalchemy.orm.session import Session
 from sqlalchemy.sql import compiler
 from sqlalchemy.sql.expression import cast
+from sqlalchemy.ext.hybrid import hybrid_property
 
 from geoalchemy2 import Geography, Geometry
 
@@ -796,4 +798,328 @@ class ShortClientTokenDecoder(ShortClientTokenTool):
             )
         )        
         return delegated_patron_identifier
+
+class ExternalIntegration(Base):
+
+    """An external integration contains configuration for connecting
+    to a third-party API.
+    """
+
+    # Possible goals of ExternalIntegrations.
+
+    # These integrations are associated with external services such as
+    # Adobe Vendor ID, which manage access to DRM-dependent content.
+    DRM_GOAL = u'drm'
+
+    # Integrations with DRM_GOAL
+    ADOBE_VENDOR_ID = u'Adobe Vendor ID'
+
+    __tablename__ = 'externalintegrations'
+    id = Column(Integer, primary_key=True)
+
+    # Each integration should have a protocol (explaining what type of
+    # code or network traffic we need to run to get things done) and a
+    # goal (explaining the real-world goal of the integration).
+    #
+    # Basically, the protocol is the 'how' and the goal is the 'why'.
+    protocol = Column(Unicode, nullable=False)
+    goal = Column(Unicode, nullable=True)
+
+    # A unique name for this ExternalIntegration. This is primarily
+    # used to identify ExternalIntegrations from command-line scripts.
+    name = Column(Unicode, nullable=True, unique=True)
+    
+    # Any additional configuration information goes into
+    # ConfigurationSettings.
+    settings = relationship(
+        "ConfigurationSetting", backref="external_integration",
+        lazy="joined", cascade="save-update, merge, delete, delete-orphan",
+    )
+
+    def __repr__(self):
+        return u"<ExternalIntegration: protocol=%s goal='%s' settings=%d ID=%d>" % (
+            self.protocol, self.goal, len(self.settings), self.id)
+
+    @classmethod
+    def lookup(cls, _db, protocol, goal):
+        integrations = _db.query(cls).filter(
+            cls.protocol==protocol, cls.goal==goal
+        )
+
+        integrations = integrations.all()
+        if len(integrations) > 1:
+            logging.warn("Multiple integrations found for '%s'/'%s'" % (protocol, goal))
+
+        if not integrations:
+            return None
+        return integrations[0]
+
+    def set_setting(self, key, value):
+        """Create or update a key-value setting for this ExternalIntegration."""
+        setting = self.setting(key)
+        setting.value = value
+        return setting
+    
+    def setting(self, key):
+        """Find or create a ConfigurationSetting on this ExternalIntegration.
+
+        :param key: Name of the setting.
+        :return: A ConfigurationSetting
+        """
+        return ConfigurationSetting.for_externalintegration(
+            key, self
+        )
+
+    def explain(self, include_secrets=False):
+        """Create a series of human-readable strings to explain an
+        ExternalIntegration's settings.
+
+        :param include_secrets: For security reasons,
+           sensitive settings such as passwords are not displayed by default.
+
+        :return: A list of explanatory strings.
+        """
+        lines = []
+        lines.append("ID: %s" % self.id)
+        if self.name:
+            lines.append("Name: %s" % self.name)
+        lines.append("Protocol/Goal: %s/%s" % (self.protocol, self.goal))
+
+        def key(setting):
+            if setting.library:
+                return setting.key, setting.library.name
+            return (setting.key, None)
+        for setting in sorted(self.settings, key=key):
+            explanation = "%s='%s'" % (setting.key, setting.value)
+            if setting.library:
+                explanation = "%s (applies only to %s)" % (
+                    explanation, setting.library.name
+                )
+            if include_secrets or not setting.is_secret:
+                lines.append(explanation)
+        return lines
+
+
+class ConfigurationSetting(Base):
+    """An extra piece of site configuration.
+
+    A ConfigurationSetting may be associated with an
+    ExternalIntegration, a Library, both, or neither.
+
+    * The secret used by the circulation manager to sign OAuth bearer
+      tokens is not associated with an ExternalIntegration or with a
+      Library.
+
+    * The link to a library's privacy policy is associated with the
+      Library, but not with any particular ExternalIntegration.
+
+    * The "website ID" for an Overdrive collection is associated with
+      an ExternalIntegration (the Overdrive integration), but not with
+      any particular Library (since multiple libraries might share an
+      Overdrive collection).
+
+    * The "identifier prefix" used to determine which library a patron
+      is a patron of, is associated with both a Library and an
+      ExternalIntegration.
+    """
+    __tablename__ = 'configurationsettings'
+    id = Column(Integer, primary_key=True)
+    external_integration_id = Column(
+        Integer, ForeignKey('externalintegrations.id'), index=True
+    )
+    library_id = Column(
+        Integer, ForeignKey('libraries.id'), index=True
+    )
+    key = Column(Unicode, index=True)
+    _value = Column(Unicode, name="value")
+
+    __table_args__ = (
+        UniqueConstraint('external_integration_id', 'library_id', 'key'),
+    )
+
+    def __repr__(self):
+        return u'<ConfigurationSetting: key=%s, ID=%d>' % (
+            self.key, self.id)
+
+    @classmethod
+    def sitewide_secret(cls, _db, key):
+        """Find or create a sitewide shared secret.
+
+        The value of this setting doesn't matter, only that it's
+        unique across the site and that it's always available.
+        """
+        secret = ConfigurationSetting.sitewide(_db, key)
+        if not secret.value:
+            secret.value = os.urandom(24).encode('hex')
+            # Commit to get this in the database ASAP.
+            _db.commit()
+        return secret.value
+
+    @classmethod
+    def explain(cls, _db, include_secrets=False):
+        """Explain all site-wide ConfigurationSettings."""
+        lines = []
+        site_wide_settings = []
+        
+        for setting in _db.query(ConfigurationSetting).filter(
+                ConfigurationSetting.library_id==None).filter(
+                    ConfigurationSetting.external_integration==None):
+            if not include_secrets and setting.key.endswith("_secret"):
+                continue
+            site_wide_settings.append(setting)
+        if site_wide_settings:
+            lines.append("Site-wide configuration settings:")
+            lines.append("---------------------------------")
+        for setting in sorted(site_wide_settings, key=lambda s: s.key):
+            lines.append("%s='%s'" % (setting.key, setting.value))
+        return lines
+
+    @classmethod
+    def sitewide(cls, _db, key):
+        """Find or create a sitewide ConfigurationSetting."""
+        return cls.for_library_and_externalintegration(_db, key, None, None)
+
+    @classmethod
+    def for_library(cls, key, library):
+        """Find or create a ConfigurationSetting for the given Library."""
+        _db = Session.object_session(library)
+        return cls.for_library_and_externalintegration(_db, key, library, None)
+
+    @classmethod
+    def for_externalintegration(cls, key, externalintegration):
+        """Find or create a ConfigurationSetting for the given
+        ExternalIntegration.
+        """
+        _db = Session.object_session(externalintegration)
+        return cls.for_library_and_externalintegration(
+            _db, key, None, externalintegration
+        )
+    
+    @classmethod
+    def for_library_and_externalintegration(
+            cls, _db, key, library, external_integration
+    ):
+        """Find or create a ConfigurationSetting associated with a Library
+        and an ExternalIntegration.
+        """
+        library_id = None
+        if library:
+            library_id = library.id
+        setting, ignore = get_one_or_create(
+            _db, ConfigurationSetting,
+            library_id=library_id, external_integration=external_integration,
+            key=key
+        )
+        return setting
+
+    @property
+    def library(self):
+        _db = Session.object_session(self)
+        if self.library_id:
+            return get_one(_db, Library, id=self.library_id)
+        return None
+
+    @hybrid_property
+    def value(self):
+        """What's the current value of this configuration setting?
+        
+        If not present, the value may be inherited from some other
+        ConfigurationSetting.
+        """
+        if self._value:
+            # An explicitly set value always takes precedence.
+            return self._value
+        elif self.library_id and self.external_integration:
+            # This is a library-specific specialization of an
+            # ExternalIntegration. Treat the value set on the
+            # ExternalIntegration as a default.
+            return self.for_externalintegration(
+                self.key, self.external_integration).value
+        elif self.library_id:
+            # This is a library-specific setting. Treat the site-wide
+            # value as a default.
+            _db = Session.object_session(self)
+            return self.sitewide(_db, self.key).value
+        return self._value
+    
+    @value.setter
+    def set_value(self, new_value):
+        self._value = new_value
+
+    @classmethod
+    def _is_secret(self, key):
+        """Should the value of the given key be treated as secret?
+
+        This will have to do, in the absence of programmatic ways of
+        saying that a specific setting should be treated as secret.
+        """
+        return any(
+            key == x or
+            key.startswith('%s_' % x) or
+            key.endswith('_%s' % x) or
+            ("_%s_" %x) in key
+            for x in ('secret', 'password')
+        )
+
+    @property
+    def is_secret(self):
+        """Should the value of this key be treated as secret?"""
+        return self._is_secret(self.key)
+
+    def value_or_default(self, default):
+        """Return the value of this setting. If the value is None,
+        set it to `default` and return that instead.
+        """
+        if self.value is None:
+            self.value = default
+        return self.value
+    
+    MEANS_YES = set(['true', 't', 'yes', 'y'])
+    @property
+    def bool_value(self):
+        """Turn the value into a boolean if possible.
+
+        :return: A boolean, or None if there is no value.
+        """
+        if self.value:
+            if self.value.lower() in self.MEANS_YES:
+                return True
+            return False
+        return None
+        
+    @property
+    def int_value(self):
+        """Turn the value into an int if possible.
+
+        :return: An integer, or None if there is no value.
+
+        :raise ValueError: If the value cannot be converted to an int.
+        """
+        if self.value:
+            return int(self.value)
+        return None
+
+    @property
+    def float_value(self):
+        """Turn the value into an float if possible.
+
+        :return: A float, or None if there is no value.
+
+        :raise ValueError: If the value cannot be converted to a float.
+        """
+        if self.value:
+            return float(self.value)
+        return None
+    
+    @property
+    def json_value(self):
+        """Interpret the value as JSON if possible.
+
+        :return: An object, or None if there is no value.
+
+        :raise ValueError: If the value cannot be parsed as JSON.
+        """
+        if self.value:
+            return json.loads(self.value)
+        return None
 


### PR DESCRIPTION
I mostly copied and pasted code from the multi-tenant branch of server_core and removed things that aren't relevant here or aren't needed yet. That includes the url, username, and password properties on ExternalIntegration, the list of sitewide settings in config.py, and the function to reload the site configuration. The one thing I left out that might be needed is the settings relationship on Library. It broke a bunch of queries and I wasn't sure if we really needed to get all the settings for a Library, or we'd be mostly looking them up one at a time.

I converted Adobe vendor ID and the sitewide base URL to be read from the db instead of the config file. I didn't bother with a migration since this isn't in production yet.