### PR TITLE
Converted controllers to return OPDS 2 catalogs.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,6 +16,7 @@ git:
 
 before_install:
   - pip install "setuptools>=18.5"
+  - sudo apt-get install -y postgresql-9.3-postgis-2.3 postgis
   - sleep 10
 
 install:

--- a/model.py
+++ b/model.py
@@ -487,6 +487,8 @@ class Library(Base):
     @property
     def urn_uri(self):
         "Return the URN as a urn: URI."
+        if not self.urn:
+            return None
         if self.urn.startswith('urn:'):
             return self.urn
         else:

--- a/opds.py
+++ b/opds.py
@@ -28,16 +28,12 @@ class OPDSCatalog(object):
     @classmethod
     def add_link_to_catalog(cls, catalog, children=None, **kwargs):
         link = dict(**kwargs)
-        links = catalog.get("links", [])
-        links.append(link)
-        catalog["links"] = links
+        catalog.setdefault("links", []).append(link)
 
     @classmethod
     def add_image_to_catalog(cls, catalog, children=None, **kwargs):
         image = dict(**kwargs)
-        images = catalog.get("images", [])
-        images.append(image)
-        catalog["images"] = images
+        catalog.setdefault("images", []).append(image)
 
     def __init__(self, _db, title, url, libraries, annotator=None):
         """Turn a list of libraries into a catalog."""

--- a/opds.py
+++ b/opds.py
@@ -7,6 +7,12 @@ class Annotator(object):
         pass
 
 class OPDSCatalog(object):
+    """Represents an OPDS 2 Catalog document.
+    https://github.com/opds-community/opds-revision/blob/master/opds-2.0.md
+
+    Within the collection role "catalogs", metadata and the navigation
+    collection role have the same semantics as in the overall OPDS 2 Catalog spec.
+    """
 
     TIME_FORMAT = '%Y-%m-%dT%H:%M:%SZ%z'
 

--- a/opds.py
+++ b/opds.py
@@ -1,202 +1,97 @@
-import datetime
-import logging
-
-from lxml import builder, etree
 from nose.tools import set_trace
-
-class AtomFeed(object):
-
-    TIME_FORMAT = '%Y-%m-%dT%H:%M:%SZ%z'
-
-    ATOM_NS = 'http://www.w3.org/2005/Atom'
-    OPDS_NS = 'http://opds-spec.org/2010/catalog'
-    SCHEMA_NS = 'http://schema.org/'
-    
-    nsmap = {
-        None: ATOM_NS,
-        'opds' : OPDS_NS,
-        'schema' : SCHEMA_NS
-    }
-
-    default_typemap = {datetime: lambda e, v: _strftime(v)}
-    E = builder.ElementMaker(typemap=default_typemap, nsmap=nsmap)
-    SCHEMA = builder.ElementMaker(typemap=default_typemap, nsmap=nsmap, namespace=SCHEMA_NS)
-       
-    @classmethod
-    def _strftime(self, date):
-        """
-        Format a date the way Atom likes it (RFC3339?)
-        """
-        return date.strftime(self.TIME_FORMAT)
-
-
-    @classmethod
-    def add_link_to_feed(cls, feed, children=None, **kwargs):
-        link = cls.E.link(**kwargs)
-        feed.append(link)
-        if children:
-            for i in children:
-                link.append(i)
-
-
-    @classmethod
-    def add_link_to_entry(cls, entry, children=None, **kwargs):
-        link = cls.E.link(**kwargs)
-        entry.append(link)
-        if children:
-            for i in children:
-                link.append(i)
-
-
-    @classmethod
-    def author(cls, *args, **kwargs):
-        return cls.E.author(*args, **kwargs)
-
-
-    @classmethod
-    def category(cls, *args, **kwargs):
-        return cls.E.category(*args, **kwargs)
-
-
-    @classmethod
-    def entry(cls, *args, **kwargs):
-        return cls.E.entry(*args, **kwargs)
-
-
-    @classmethod
-    def id(cls, *args, **kwargs):
-        return cls.E.id(*args, **kwargs)
-
-
-    @classmethod
-    def link(cls, *args, **kwargs):
-        return cls.E.link(*args, **kwargs)
-
-
-    @classmethod
-    def makeelement(cls, *args, **kwargs):
-        return cls.E._makeelement(*args, **kwargs)
-
-
-    @classmethod
-    def name(cls, *args, **kwargs):
-        return cls.E.name(*args, **kwargs)
-
-    @classmethod
-    def summary(cls, *args, **kwargs):
-        return cls.E.summary(*args, **kwargs)
-
-
-    @classmethod
-    def title(cls, *args, **kwargs):
-        return cls.E.title(*args, **kwargs)
-
-
-    @classmethod
-    def update(cls, *args, **kwargs):
-        return cls.E.update(*args, **kwargs)
-
-
-    @classmethod
-    def updated(cls, *args, **kwargs):
-        return cls.E.updated(*args, **kwargs)
-
-
-    def __init__(self, title, url):
-        self.feed = self.E.feed(
-            self.E.id(url),
-            self.E.title(title),
-            self.E.updated(self._strftime(datetime.datetime.utcnow())),
-            self.E.link(href=url, rel="self",
-                        type=OPDSFeed.NAVIGATION_FEED_TYPE),
-        )
-
-
-    def __unicode__(self):
-        if self.feed is None:
-            return None
-
-        string_tree = etree.tostring(self.feed, pretty_print=True)
-        return string_tree.encode("utf8")
-
-
-class OPDSFeed(AtomFeed):
-
-    GENERIC_OPDS_TYPE = "application/atom+xml;profile=opds-catalog"
-    NAVIGATION_FEED_TYPE = GENERIC_OPDS_TYPE + ";kind=navigation"
-    ENTRY_TYPE = "application/atom+xml;type=entry;profile=opds-catalog"
-
-    CATALOG_REL = "http://opds-spec.org/catalog"
-    THUMBNAIL_REL = "http://opds-spec.org/image/thumbnail"
-
-    CACHE_TIME = 3600 * 12
+import json
 
 class Annotator(object):
 
     def annotate_feed(self, feed):
         pass
 
-    
-class NavigationFeed(OPDSFeed):
-   
+class OPDSCatalog(object):
+
+    TIME_FORMAT = '%Y-%m-%dT%H:%M:%SZ%z'
+
+    OPDS_TYPE = "application/opds+json"
+    OPDS_1_TYPE = "application/atom+xml;profile=opds-catalog;kind=acquisition"
+
+    CATALOG_REL = "http://opds-spec.org/catalog"
+    THUMBNAIL_REL = "http://opds-spec.org/image/thumbnail"
+
+    CACHE_TIME = 3600 * 12
+
+    @classmethod
+    def _strftime(cls, date):
+        """
+        Format a date the way Atom likes it (RFC3339?)
+        """
+        return date.strftime(cls.TIME_FORMAT)
+
+    @classmethod
+    def add_link_to_catalog(cls, catalog, children=None, **kwargs):
+        link = dict(**kwargs)
+        links = catalog.get("links", [])
+        links.append(link)
+        catalog["links"] = links
+
+    @classmethod
+    def add_image_to_catalog(cls, catalog, children=None, **kwargs):
+        image = dict(**kwargs)
+        images = catalog.get("images", [])
+        images.append(image)
+        catalog["images"] = images
+
     def __init__(self, _db, title, url, libraries, annotator=None):
-        """Turn a list of libraries into a feed."""
-        super(NavigationFeed, self).__init__(title, url)
-        
+        """Turn a list of libraries into a catalog."""
         if not annotator:
             annotator = Annotator()
-        self.annotator = annotator
-       
+
+        self.catalog = dict(metadata=dict(title=title), catalogs=[])
+
+        self.add_link_to_catalog(self.catalog, rel="self",
+                                 href=url, type=self.OPDS_TYPE)
         for library in libraries:
             if not isinstance(library, tuple):
                 library = (library,)
-            self.feed.append(self.library_entry(*library))
-        annotator.annotate_feed(self)
-        
-    @classmethod
-    def library_entry(cls, library, distance=None):
-        entry = AtomFeed.entry(
-            AtomFeed.id(library.urn_uri),
-            AtomFeed.title(library.name),
-            AtomFeed.updated(cls._strftime(library.timestamp))
-        )
+            self.catalog["catalogs"].append(self.library_catalog(*library))
+        annotator.annotate_catalog(self)
 
+    @classmethod
+    def library_catalog(cls, library, distance=None):
+        metadata = dict(
+            id=library.urn_uri,
+            title=library.name,
+            updated=cls._strftime(library.timestamp),
+        )
         if distance is not None:
-            distance_tag = AtomFeed.SCHEMA.distance()
-            distance_tag.text = "%d km." % (distance/1000)
-            entry.append(distance_tag)
-        
-        # Add description.
+            metadata["distance"] = "%d km." % (distance/1000)
+
         if library.description:
-            content = AtomFeed.E.content(
-                type="text"
-            )
-            content.text = library.description
-            entry.append(content)
-        
-        # Add links.
+            metadata["description"] = library.description
+        catalog = dict(metadata=metadata)
+
         if library.opds_url:
-            AtomFeed.add_link_to_entry(
-                entry,
-                href=library.opds_url,
-                rel=cls.CATALOG_REL,
-                type=cls.GENERIC_OPDS_TYPE
-            )
-        
+            # TODO: Keep track of whether each library uses OPDS 1 or 2?
+            cls.add_link_to_catalog(catalog, rel=cls.CATALOG_REL,
+                                    href=library.opds_url,
+                                    type=cls.OPDS_1_TYPE)
+
         if library.web_url:
-            AtomFeed.add_link_to_entry(
-                entry,
-                href=library.web_url,
-                rel="alternate",
-                type="text/html"
-            )
+            cls.add_link_to_catalog(catalog, rel="alternate",
+                                    href=library.web_url,
+                                    type="text/html")
 
         if library.logo:
-            AtomFeed.add_link_to_entry(
-                entry,
-                href=library.logo_data_uri,
-                type="image/png",
-                rel=cls.THUMBNAIL_REL
-            )
+            cls.add_image_to_catalog(catalog, rel=cls.THUMBNAIL_REL,
+                                     href=library.logo_data_uri,
+                                     type="image/png")
 
-        return entry
+        return catalog
+
+    def __unicode__(self):
+        if self.catalog is None:
+            return None
+
+        return json.dumps(self.catalog)
+
+
+                                   
+        

--- a/opds.py
+++ b/opds.py
@@ -7,11 +7,14 @@ class Annotator(object):
         pass
 
 class OPDSCatalog(object):
-    """Represents an OPDS 2 Catalog document.
+    """Represents an OPDS 2 Catalog Document.
     https://github.com/opds-community/opds-revision/blob/master/opds-2.0.md
 
-    Within the collection role "catalogs", metadata and the navigation
-    collection role have the same semantics as in the overall OPDS 2 Catalog spec.
+    This document may stand on its own, or be contained within another
+    OPDS 2 Catalog Document in a collection with the "catalogs" role.
+
+    Within the "catalogs" role, metadata and the navigation collection role
+    have the same semantics as in the overall OPDS 2 Catalog spec.
     """
 
     TIME_FORMAT = '%Y-%m-%dT%H:%M:%SZ%z'

--- a/tests/test_opds.py
+++ b/tests/test_opds.py
@@ -2,48 +2,43 @@ from nose.tools import (
     eq_,
     set_trace,
 )
-
-import feedparser
-from lxml import etree
+import json
 
 from . import (
     DatabaseTest,
 )
 
-from opds import NavigationFeed
+from opds import OPDSCatalog
 
-class TestOPDS(DatabaseTest):
+class TestOPDSCatalog(DatabaseTest):
 
-    def test_library_feed(self):
+    def test_library_catalogs(self):
         l1 = self._library("The New York Public Library")
         l2 = self._library("Brooklyn Public Library")
         class TestAnnotator(object):
-            def annotate_feed(self, feed_obj):
-                new_tag = feed_obj.E.randomtag()
-                new_tag.text = "Random text inserted by annotator."
-                feed_obj.feed.append(new_tag)
+            def annotate_catalog(self, catalog_obj):
+                catalog_obj.catalog['metadata']['random'] = "Random text inserted by annotator."
                 
-        feed = NavigationFeed(
-            self._db, "A Feed!", "http://url/", [l1, l2],
+        catalog = OPDSCatalog(
+            self._db, "A Catalog!", "http://url/", [l1, l2],
             TestAnnotator()
         )
-        feed = unicode(feed)
-        parsed = feedparser.parse(feed)
+        catalog = unicode(catalog)
+        parsed = json.loads(catalog)
 
-        # The feed is labeled appropriately.
-        eq_("A Feed!", parsed['feed']['title'])
-        eq_("http://url/", parsed['feed']['link'])
+        # The catalog is labeled appropriately.
+        eq_("A Catalog!", parsed['metadata']['title'])
+        [self_link] = parsed['links']
+        eq_("http://url/", self_link['href'])
+        eq_("self", self_link['rel'])
         
-        # The annotator modified the feed in passing.
-        assert (
-            '<randomtag>Random text inserted by annotator.</randomtag>'
-            in feed
-        )
+        # The annotator modified the catalog in passing.
+        eq_("Random text inserted by annotator.", parsed['metadata']['random'])
         
-        # Each library became an entry in the feed.
-        eq_([l1.name, l2.name], [x['title'] for x in parsed['entries']])
+        # Each library became a catalog in the catalogs collection.
+        eq_([l1.name, l2.name], [x['metadata']['title'] for x in parsed['catalogs']])
         
-    def test_library_entry(self):
+    def test_library_catalog(self):
 
         library = self._library("The New York Public Library")
         library.urn = "123-abc"
@@ -52,29 +47,26 @@ class TestOPDS(DatabaseTest):
         library.web_url = "https://nypl.org/"
         library.logo = "Fake logo"
         
-        entry = NavigationFeed.library_entry(library)
-        entry = etree.tostring(entry)
-        feed = feedparser.parse(entry)
-        [entry] = feed['entries']
-        eq_(library.name, entry['title'])
-        eq_(library.urn_uri, entry['id'])
-        [content] = entry['content']
-        eq_(library.description, content['value'])
-        eq_("text/plain", content['type'])
+        catalog = OPDSCatalog.library_catalog(library)
+        metadata = catalog['metadata']
+        eq_(library.name, metadata['title'])
+        eq_(library.urn_uri, metadata['id'])
+        eq_(library.description, metadata['description'])
 
-        eq_(entry['updated'], NavigationFeed._strftime(library.timestamp))
+        eq_(metadata['updated'], OPDSCatalog._strftime(library.timestamp))
 
-        [web, opds, logo] = sorted(entry['links'], key=lambda x: x['rel'])
+        [web, opds] = sorted(catalog['links'], key=lambda x: x['rel'])
+        [logo] = catalog['images']
 
         eq_(library.web_url, web['href'])
         eq_("alternate", web['rel'])
         eq_("text/html", web['type'])
 
         eq_(library.opds_url, opds['href'])
-        eq_(NavigationFeed.CATALOG_REL, opds['rel'])
-        eq_(NavigationFeed.GENERIC_OPDS_TYPE, opds['type'])
+        eq_(OPDSCatalog.CATALOG_REL, opds['rel'])
+        eq_(OPDSCatalog.OPDS_1_TYPE, opds['type'])
 
         eq_(library.logo_data_uri, logo['href'])
-        eq_(NavigationFeed.THUMBNAIL_REL, logo['rel'])
+        eq_(OPDSCatalog.THUMBNAIL_REL, logo['rel'])
         eq_("image/png", logo['type'])
 

--- a/util/app_server.py
+++ b/util/app_server.py
@@ -12,22 +12,16 @@ from util.flask_util import problem
 from util.problem_detail import ProblemDetail
 import traceback
 import logging
-from opds import (
-    OPDSFeed,
-    NavigationFeed,
-)
+from opds import OPDSCatalog
+
 from sqlalchemy.orm.session import Session
 from sqlalchemy.orm.exc import (
     NoResultFound,
 )
 
-def feed_response(feed, cache_for=OPDSFeed.CACHE_TIME):
-    content_type = OPDSFeed.NAVIGATION_FEED_TYPE
-    return _make_response(feed, content_type, cache_for)
-
-def entry_response(entry, cache_for=OPDSFeed.CACHE_TIME):
-    content_type = OPDSFeed.ENTRY_TYPE
-    return _make_response(entry, content_type, cache_for)
+def catalog_response(catalog, cache_for=OPDSCatalog.CACHE_TIME):
+    content_type = OPDSCatalog.OPDS_TYPE
+    return _make_response(catalog, content_type, cache_for)
 
 def _make_response(content, content_type, cache_for):
     if isinstance(content, etree._Element):


### PR DESCRIPTION
This branch changes the library registry to use [OPDS 2](https://github.com/opds-community/opds-revision/blob/master/opds-2.0.md), with a custom "catalogs" collection role. Within "catalogs", the metadata and navigation collection are the same as in the overall OPDS 2 spec.

The register endpoint also returns an OPDS catalog now, but it doesn't have a self link yet.