### PR TITLE
Auth document parser

### DIFF
--- a/authentication_document.py
+++ b/authentication_document.py
@@ -1,0 +1,178 @@
+import json
+
+class AuthenticationDocument(object):
+    """Parse an Authentication For OPDS document, including the
+    Library Simplified-specific extensions, extracting all the information
+    that's of interest to the library registry.
+    """
+
+    ANONYMOUS_ACCESS_REL = "https://librarysimplified.org/rel/auth/anonymous"
+
+    COVERAGE_EVERYWHERE = "everywhere"
+    
+    # The list of color schemes supported by SimplyE.
+    SIMPLYE_COLOR_SCHEMES = [
+        "red", "blue", "gray", "gold", "green", "teal", "purple",
+    ]   
+    
+    PUBLIC_AUDIENCE = 'public'
+    AUDIENCES = [PUBLIC_AUDIENCE, 'educational-primary',
+                 'educational-secondary', 'research', 'print-disability',
+                 'other']
+    
+    def __init__(self, id, type, service_description, color_scheme, 
+                 collection_size, public_key, audiences, service_area,
+                 focus_area, links):
+        self.id = id
+        self.title = title
+        self.service_description = service_description
+        self.color_scheme = color_scheme
+        self.logo = logo
+        self.collection_size = collection_size
+        self.public_key = public_key
+        self.audiences = audiences or [self.PUBLIC_AUDIENCE]
+        self.service_area = self.parse_geography(service_area)
+        self.focus_area = self.parse_geography(focus_area)
+        self.links = links
+        self.website = self.extract_link(
+            rel="alternate", require_type="text/html"
+        )
+        self.registration = self.extract_link(rel="register")
+        self.root = self.extract_link(
+            rel="start",
+            prefer_type="application/atom+xml;profile=opds-catalog"
+        )
+        logo = self.extract_link(rel="logo")
+        if logo.startswith('data:'):
+            self.logo = logo
+            self.logo_link = None
+        else:
+            self.logo = None
+            self.logo_link = logo
+        self.anonymous_access = False
+        if (type == self.ANONYMOUS_ACCESS
+            or isinstance(type, list) and self.ANONYMOUS_ACCESS in type):
+            self.anonymous_access = True
+
+    def extract_link(self, rel, require_type=None, prefer_type=None):
+        return self._extract_link(
+            self.links.get(rel), require_type, prefer_type
+        )
+
+    @classmethod
+    def parse_coverage(self, _db, coverage, place_class=Place):
+        """Derive Place objects from an Authentication For OPDS coverage
+        object (i.e. a value for `service_area` or `focus_area`)
+
+        :param coverage: An Authentication For OPDS coverage object.
+
+        :param place_class: In unit tests, pass in a mock replacement
+        for the Place class here.
+
+        :return: A 3-tuple (places, unknown, ambiguous).
+
+        `places` is a list of Place model objects.
+
+        `unknown` is a coverage object representing the subset of
+        `coverage` that had no corresponding Place objects.
+
+        `ambiguous` is a coverage object representing
+        the subset of `coverage` that had more than one corresponding
+        Place object.
+        """
+        place_objs = []
+        unknown = defaultdict(list)
+        ambiguous = defaultdict(list)
+        if coverage == self.COVERAGE_EVERYWHERE:
+            # This library covers the entire universe! No need to
+            # parse anything.
+            place_objs.append(place_class.everywhere(_db))
+            coverage = dict()
+            
+        for country, places in coverage.items():
+            if places == self.COVERAGE_EVERYWHERE:
+                # This library covers an entire country.
+                try:
+                    place = place_class.lookup_by_name(
+                        _db, country, place_type=Place.COUNTRY,
+                    )
+                except MultipleResultsFound, e:
+                    # A country was ambiguously named -- not very likely.
+                    ambiguous[country] = self.COVERAGE_EVERYWHERE
+                if place:
+                    places.append(place)
+                else:
+                    # Either this isn't a recognized country
+                    # or we don't have a geography for it.
+                    unknown[country] = self.COVERAGE_EVERYWHERE
+            else:
+                # This library covers a list of places within a
+                # country.
+                if isinstance(places, basestring):
+                    # This is invalid -- you're supposed to always
+                    # pass in a list -- but we can support it.
+                    places = [places]
+                for place in places:
+                    try:
+                        place_obj = place_class.lookup_inside(
+                            _db, place, must_be_inside=country
+                        )
+                    except MultipleResultsFound, e:
+                        # The place was ambiguously named.
+                        append_to = ambiguous[country] 
+                    if place_obj:
+                        # We found it.
+                        append_to = place_objs
+                    else:
+                        # We couldn't find any place with this name.
+                        append_to = unknown[country]
+                    append_to.append(place)
+        return place_objs, unknown, ambiguous
+    
+    @classmethod
+    def _extract_link(self, links, require_type=None, prefer_type=None):
+        if not links:
+            # There are no links with this relation.
+            return None
+        if not isinstance(links, list):
+            # A single link.
+            links = [links]
+        good_enough = None
+        for link in links:
+            if not require_type and not prefer_type:
+                # Any link with this relation will work. Return the
+                # first one we see.
+                return link
+
+            # Beyond this point, either require_type or prefer_type is
+            # set, so the type of the link becomes relevant.
+            type = link.get('type', '')
+            
+            if type.startswith(require_type):
+                # If require_type is True, this means we have found a
+                # link of the required type. If prefer_type is True,
+                # this means we will never find a better link than
+                # this one. Return it immediately.
+                return link
+            if not require_type and not good_enough:
+                # We would prefer a link of a certain type, but if it
+                # turns out there is no such link, we will accept the
+                # first link of the given type.
+                good_enough = link
+        return good_enough
+            
+    @classmethod
+    def from_string(self, s):
+        data = json.loads(s)
+        return AuthenticationDocument(
+            id=data.get('id', None),
+            type=data.get('type', []),
+            service_description=data.get('service_description', None),
+            color_scheme=data.get('color_scheme'),
+            collection_size=data.get('collection_size'),
+            public_key=data.get('public_key'),
+            audiences=data.get('audience'),
+            service_area=data.get('service_area'),
+            focus_area=data.get('service_area'),
+            links=data.get('links', {})
+        )

--- a/authentication_document.py
+++ b/authentication_document.py
@@ -189,10 +189,14 @@ class AuthenticationDocument(object):
     @classmethod
     def from_string(cls, _db, s, place_class=Place):
         data = json.loads(s)
+        return cls.from_dict(_db, data, place_class)
+
+    @classmethod
+    def from_dict(cls, _db, data, place_class=Place):
         return AuthenticationDocument(
             _db,
             id=data.get('id', None),
-            title=data.get('title', None),
+            title=data.get('title', data.get('name', None)),
             type=data.get('type', []),
             service_description=data.get('service_description', None),
             color_scheme=data.get('color_scheme'),

--- a/authentication_document.py
+++ b/authentication_document.py
@@ -65,7 +65,7 @@ class AuthenticationDocument(object):
 
     def extract_link(self, rel, require_type=None, prefer_type=None):
         return self._extract_link(
-            self.links.get(rel), require_type, prefer_type
+            self.links, rel, require_type, prefer_type
         )
 
     @classmethod
@@ -138,9 +138,13 @@ class AuthenticationDocument(object):
         return place_objs, unknown, ambiguous
     
     @classmethod
-    def _extract_link(cls, links, require_type=None, prefer_type=None):
+    def _extract_link(cls, links, rel, require_type=None, prefer_type=None):
         if not links:
-            # There are no links with this relation.
+            # There are no links, period.
+            return None
+        links = links.get(rel)
+        if not links:
+            # There are no links with this link relation.
             return None
         if not isinstance(links, list):
             # A single link.
@@ -156,12 +160,14 @@ class AuthenticationDocument(object):
             # set, so the type of the link becomes relevant.
             type = link.get('type', '')
             
-            if type.startswith(require_type):
-                # If require_type is True, this means we have found a
-                # link of the required type. If prefer_type is True,
-                # this means we will never find a better link than
-                # this one. Return it immediately.
-                return link
+            if type:
+                if (require_type and type.startswith(require_type)
+                    or prefer_type and type.startswith(prefer_type)):
+                    # If we have a require_type, this means we have
+                    # met the requirement. If we have a prefer_type,
+                    # we will not find a better link than this
+                    # one. Return it immediately.
+                    return link
             if not require_type and not good_enough:
                 # We would prefer a link of a certain type, but if it
                 # turns out there is no such link, we will accept the

--- a/authentication_document.py
+++ b/authentication_document.py
@@ -126,16 +126,15 @@ class AuthenticationDocument(object):
                         place_obj = place_class.lookup_inside(
                             _db, place, must_be_inside=country
                         )
+                        if place_obj:
+                            # We found it.
+                            place_objs.append(place_obj)
+                        else:
+                            # We couldn't find any place with this name.
+                            unknown[country].append(place)
                     except MultipleResultsFound, e:
                         # The place was ambiguously named.
-                        append_to = ambiguous[country] 
-                    if place_obj:
-                        # We found it.
-                        append_to = place_objs
-                    else:
-                        # We couldn't find any place with this name.
-                        append_to = unknown[country]
-                    append_to.append(place)
+                        ambiguous[country].append(place)
         return place_objs, unknown, ambiguous
     
     @classmethod

--- a/authentication_document.py
+++ b/authentication_document.py
@@ -1,5 +1,6 @@
 from collections import defaultdict
 import json
+from nose.tools import set_trace
 from sqlalchemy.orm.exc import (
     MultipleResultsFound,
 )
@@ -101,18 +102,18 @@ class AuthenticationDocument(object):
             if places == cls.COVERAGE_EVERYWHERE:
                 # This library covers an entire country.
                 try:
-                    place = place_class.lookup_by_name(
-                        _db, country, place_type=Place.COUNTRY,
+                    place_obj = place_class.lookup_by_name(
+                        _db, country, place_type=Place.NATION,
                     )
+                    if place_obj:
+                        place_objs.append(place_obj)
+                    else:
+                        # Either this isn't a recognized country
+                        # or we don't have a geography for it.
+                        unknown[country] = cls.COVERAGE_EVERYWHERE
                 except MultipleResultsFound, e:
                     # A country was ambiguously named -- not very likely.
                     ambiguous[country] = cls.COVERAGE_EVERYWHERE
-                if place:
-                    places.append(place)
-                else:
-                    # Either this isn't a recognized country
-                    # or we don't have a geography for it.
-                    unknown[country] = cls.COVERAGE_EVERYWHERE
             else:
                 # This library covers a list of places within a
                 # country.

--- a/tests/test_authentication_document.py
+++ b/tests/test_authentication_document.py
@@ -162,3 +162,51 @@ class TestParseCoverage(object):
             places, {"US": "Nowheresville"},
             expected_unknown={"US": ["Nowheresville"]}
         )
+
+
+class TestLinkExtractor(object):
+    """Test the _extract_link helper method."""
+
+    def test_no_matching_link(self):
+        links = {'alternate': [dict(href="http://foo/", type="text/html")]}
+
+        # There is no link with the given relation.
+        eq_(None, AuthDoc._extract_link(links, 'self'))
+
+        # There is a link with the given relation, but the type is wrong.
+        eq_(
+            None,
+            AuthDoc._extract_link(
+                links, 'alternate', require_type="text/plain"
+            )
+        )
+        
+
+    def test_prefer_type(self):
+        """Test that prefer_type holds out for the link you're
+        looking for.
+        """
+        first_link = dict(href="http://foo/", type="text/html")
+        second_link = dict(href="http://bar/", type="text/plain;charset=utf-8")
+        links = {'alternate': [first_link, second_link]}
+
+        # We would prefer the second link.
+        eq_(second_link,
+            AuthDoc._extract_link(
+                links, 'alternate', prefer_type="text/plain"
+            )
+        )
+
+        # We would prefer the first link.
+        eq_(first_link,
+            AuthDoc._extract_link(
+                links, 'alternate', prefer_type="text/html"
+            )
+        )
+        
+        # The type we prefer is not available, so we get the first link.
+        eq_(first_link,
+            AuthDoc._extract_link(
+                links, 'alternate', prefer_type="application/xhtml+xml"
+            )
+        )

--- a/tests/test_authentication_document.py
+++ b/tests/test_authentication_document.py
@@ -210,3 +210,55 @@ class TestLinkExtractor(object):
                 links, 'alternate', prefer_type="application/xhtml+xml"
             )
         )
+
+    def test_empty_document(self):
+        """Provide an empty Authentication For OPDS document to test
+        default values.
+        """
+        place = MockPlace()
+        everywhere = place.everywhere(None)
+        parsed = AuthDoc.from_string(None, "{}", place)        
+        
+        # In the absence of specific information, it's assumed the
+        # OPDS server is open to everyone.
+        eq_(everywhere, parsed.service_area)
+        eq_(everywhere, parsed.focus_area)
+        eq_([parsed.PUBLIC_AUDIENCE], parsed.audiences)
+
+        eq_(None, parsed.id)
+        eq_(None, parsed.title)
+        eq_(None, parsed.service_description)
+        eq_(None, parsed.color_scheme)
+        eq_(None, parsed.collection_size)
+        eq_(None, parsed.public_key)
+        eq_(None, parsed.website)
+        eq_(None, parsed.registration)
+        eq_(None, parsed.root)
+        eq_({}, parsed.links)
+        eq_(None, parsed.logo)
+        eq_(None, parsed.logo_link)
+        eq_(False, parsed.anonymous_access)
+
+    def test_minimal_document(self):
+        """Test a real, albeit minimal, Authentication For OPDS document."""
+        document = """{"title": "Ansonia Public Library", "links": {"logo": {"href": "data:image/png;base64,some-image-data", "type": "image/png"}, "alternate": {"href": "http://ansonialibrary.org", "type": "text/html"}}, "providers": {"http://librarysimplified.org/terms/auth/library-barcode": {"methods": {"http://opds-spec.org/auth/basic": {"inputs": {"login": {"keyboard": "Default"}, "password": {"keyboard": "Default"}}, "labels": {"login": "Barcode", "password": "PIN"}}}, "name": "Library Barcode"}}, "service_description": "Serving Ansonia, CT", "color_scheme": "gold", "id": "c90903e0-d438-4c8d-ac35-94824d769e2c", "features": {"disabled": [], "enabled": ["https://librarysimplified.org/rel/policy/reservations"]}}"""
+        place = MockPlace()
+        everywhere = place.everywhere(None)
+        parsed = AuthDoc.from_string(None, document, place)
+        
+        # Basic information about the OPDS server has been put into
+        # the AuthenticationDocument object.
+        eq_("c90903e0-d438-4c8d-ac35-94824d769e2c", parsed.id)
+        eq_("Ansonia Public Library", parsed.title)
+        eq_("Serving Ansonia, CT", parsed.service_description)
+        eq_("gold", parsed.color_scheme)
+        # collection size
+        # public key
+        eq_({u'href': u'http://ansonialibrary.org', u'type': u'text/html'},
+            parsed.website)
+        # registration
+        # root
+        # links
+        eq_("data:image/png;base64,some-image-data", parsed.logo)
+        eq_(None, parsed.logo_link)
+        # anonymous access

--- a/tests/test_authentication_document.py
+++ b/tests/test_authentication_document.py
@@ -239,9 +239,27 @@ class TestLinkExtractor(object):
         eq_(None, parsed.logo_link)
         eq_(False, parsed.anonymous_access)
 
+#"start": [{"href": "http://catalog.example.com/", "type": "text/html/"}, {"href": "http://opds.example.com/", "type": "application/atom+xml;profile=opds-catalog"}
+
+#    "providers": {"http://librarysimplified.org/terms/auth/library-barcode": {"methods": {"http://opds-spec.org/auth/basic": {"inputs": {"login": {"keyboard": "Default"}, "password": {"keyboard": "Default"}}, "labels": {"login": "Barcode", "password": "PIN"}}}, "name": "Library Barcode"}},
+        
     def test_minimal_document(self):
         """Test a real, albeit minimal, Authentication For OPDS document."""
-        document = """{"title": "Ansonia Public Library", "links": {"logo": {"href": "data:image/png;base64,some-image-data", "type": "image/png"}, "alternate": {"href": "http://ansonialibrary.org", "type": "text/html"}}, "providers": {"http://librarysimplified.org/terms/auth/library-barcode": {"methods": {"http://opds-spec.org/auth/basic": {"inputs": {"login": {"keyboard": "Default"}, "password": {"keyboard": "Default"}}, "labels": {"login": "Barcode", "password": "PIN"}}}, "name": "Library Barcode"}}, "service_description": "Serving Ansonia, CT", "color_scheme": "gold", "id": "c90903e0-d438-4c8d-ac35-94824d769e2c", "features": {"disabled": [], "enabled": ["https://librarysimplified.org/rel/policy/reservations"]}}"""
+        document = """
+{"id": "c90903e0-d438-4c8d-ac35-94824d769e2c",
+ "title": "Ansonia Public Library", 
+ "links": {
+    "logo": {"href": "data:image/png;base64,some-image-data", "type": "image/png"}, 
+    "alternate": {"href": "http://ansonialibrary.org", "type": "text/html"},
+    "register": {"href": "http://example.com/get-a-card/", "type": "text/html"}
+ },
+    "service_description": "Serving Ansonia, CT",
+    "color_scheme": "gold",
+
+    "collection_size": {"eng": 100, "spa": 20},
+    "public_key": "a public key",
+    "features": {"disabled": [], "enabled": ["https://librarysimplified.org/rel/policy/reservations"]}
+}"""
         place = MockPlace()
         everywhere = place.everywhere(None)
         parsed = AuthDoc.from_string(None, document, place)
@@ -252,11 +270,12 @@ class TestLinkExtractor(object):
         eq_("Ansonia Public Library", parsed.title)
         eq_("Serving Ansonia, CT", parsed.service_description)
         eq_("gold", parsed.color_scheme)
-        # collection size
-        # public key
+        eq_({"eng": 100, "spa": 20}, parsed.collection_size)
+        eq_("a public key", parsed.public_key)
         eq_({u'href': u'http://ansonialibrary.org', u'type': u'text/html'},
             parsed.website)
-        # registration
+        eq_({"href": "http://exmample.com/get-a-card/", "type": "text/html"},
+            parsed.registration)
         # root
         # links
         eq_("data:image/png;base64,some-image-data", parsed.logo)

--- a/tests/test_authentication_document.py
+++ b/tests/test_authentication_document.py
@@ -1,0 +1,69 @@
+from collections import defaultdict
+import json
+from nose.tools import (
+    assert_raises_regexp,
+    assert_raises,
+    eq_,
+    set_trace,
+)
+from sqlalchemy.orm.exc import (
+    MultipleResultsFound,
+)
+from authentication_document import AuthenticationDocument
+
+# Alias for a long class name
+AuthDoc = AuthenticationDocument
+
+class MockPlace(object):
+    """Used to test AuthenticationDocument.parse_coverage."""
+
+    # Used to indicate that a place name is ambiguous.
+    AMBIGUOUS = object()
+
+    # Used to indicate coverage through the universe or through a
+    # country.
+    EVERYWHERE = object()
+    
+    def __init__(self, by_name=None, is_inside=None):
+        self.by_name = by_name or dict()
+        self.is_inside = is_inside or dict()
+
+    def _lookup(self, look_in):
+        place = look_in.get(name)
+        if place is self.AMBIGUOUS:
+            raise MultipleResultsFound()
+        return place
+
+    def lookup_by_name(self, _db, name, place_type):
+        return self._lookup(self.by_name)
+        
+    def lookup_inside(self, _db, name, must_be_inside):
+        return self._lookup(self.is_inside)
+
+    def everywhere(self, _db):
+        return self.EVERYWHERE
+
+class TestParseCoverage(object):
+
+    def parse_places(self, mock_place, coverage_object, expected_places=None,
+                     expected_unknown=None, expected_ambiguous=None):
+        """Call AuthenticationDocument.parse_coverage. Verify that the
+        dictionaries of unknown and ambiguous place names are empty,
+        and that the parsed list of places is `expected`.
+        """
+        place_objs, unknown, ambiguous = AuthDoc.parse_coverage(
+            None, coverage_object, mock_place
+        )
+        empty = defaultdict(list)
+        expected_places = expected_places or []
+        expected_unknown = expected_unknown or empty
+        expected_ambiguous = expected_ambiguous or empty
+        eq_(expected_places, place_objs)
+        eq_(expected_unknown, unknown)
+        eq_(expected_ambiguous, ambiguous)
+        
+    def test_universal_coverage(self):
+        places = MockPlace()
+        self.parse_places(
+            places, AuthDoc.COVERAGE_EVERYWHERE, [MockPlace.EVERYWHERE]
+        )

--- a/tests/test_authentication_document.py
+++ b/tests/test_authentication_document.py
@@ -50,9 +50,9 @@ class TestParseCoverage(object):
     
     def parse_places(self, mock_place, coverage_object, expected_places=None,
                      expected_unknown=None, expected_ambiguous=None):
-        """Call AuthenticationDocument.parse_coverage. Verify that the
-        dictionaries of unknown and ambiguous place names are empty,
-        and that the parsed list of places is `expected`.
+        """Call AuthenticationDocument.parse_coverage. Verify that the parsed
+        list of places, as well as the dictionaries of unknown and
+        ambiguous place names, are as expected.
         """
         place_objs, unknown, ambiguous = AuthDoc.parse_coverage(
             None, coverage_object, mock_place


### PR DESCRIPTION
This branch introduces the `AuthenticationDocument` class, which represents the result of parsing an Authentication For OPDS document (with our extensions). JSON coverage objects are parsed into Place objects, links are extracted, etc.

I noticed two problems when looking at the Authentication for OPDS documents we currently serve. First, we send the name of the library as `name` rather than `title`. Second, we don't send the `type` field. Instead, we send `providers`, which is either an old name for what is now called `type` or is something slightly different--at any rate, I think it's not compliant with the current spec. I'll investigate this more later.