### PR TITLE
Generate a short name and shared secret if the library has a public key.

### DIFF
--- a/model.py
+++ b/model.py
@@ -208,11 +208,11 @@ class Library(Base):
     # The library's logo.
     logo = Column(Unicode)
 
-    # To issue Adobe IDs for this library, the registry must share a
+    # To issue Short Client Tokens for this library, the registry must share a
     # short name and a secret with them.
 
-    adobe_short_name = Column(Unicode, index=True)
-    adobe_shared_secret = Column(Unicode)
+    short_name = Column(Unicode, index=True)
+    shared_secret = Column(Unicode)
 
     aliases = relationship("LibraryAlias", backref='library')
     delegated_patron_identifiers = relationship(
@@ -222,16 +222,16 @@ class Library(Base):
 
     __table_args__ = (
         UniqueConstraint('urn'),
-        UniqueConstraint('adobe_short_name'),
+        UniqueConstraint('short_name'),
     )
 
-    @validates('adobe_short_name')
-    def validate_adobe_short_name(self, key, value):
+    @validates('short_name')
+    def validate_short_name(self, key, value):
         if not value:
             return value
         if '|' in value:
             raise ValueError(
-                'Adobe short name cannot contain the pipe character.'
+                'Short name cannot contain the pipe character.'
             )
         return value.upper()
     
@@ -897,12 +897,12 @@ class ShortClientTokenDecoder(ShortClientTokenTool):
         library_short_name = library_short_name.upper()
 
         # Look up the Library object based on short name.
-        library = get_one(_db, Library, adobe_short_name=library_short_name)
+        library = get_one(_db, Library, short_name=library_short_name)
         if not library:
             raise ValueError(
                 "I don't know how to handle tokens from library \"%s\"" % library_short_name
             )
-        secret = library.adobe_shared_secret
+        secret = library.shared_secret
         
         try:
             expiration = float(expiration)

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,3 +12,4 @@ requests
 sqlalchemy
 uwsgi
 Flask-Babel
+pycryptodome

--- a/scripts.py
+++ b/scripts.py
@@ -170,10 +170,10 @@ class AddLibraryScript(Script):
             '--web', help="URL of the library's web server."
         )
         parser.add_argument(
-            '--adobe-short-name', help="Short name of the library for Adobe Vendor ID purposes."
+            '--short-name', help="Short name of the library for Adobe Vendor ID purposes."
         )
         parser.add_argument(
-            '--adobe-shared-secret', help="Shared secret between the library and the registry for Adobe Vendor ID purposes."
+            '--shared-secret', help="Shared secret between the library and the registry for Adobe Vendor ID purposes."
         )
         parser.add_argument('--place', nargs='+',
                             help="External ID of the library's service area.")
@@ -188,8 +188,8 @@ class AddLibraryScript(Script):
         description = parsed.description
         aliases = parsed.alias
         places = parsed.place
-        adobe_short_name = parsed.adobe_short_name
-        adobe_shared_secret = parsed.adobe_shared_secret
+        short_name = parsed.short_name
+        shared_secret = parsed.shared_secret
         
         library, is_new = get_one_or_create(self._db, Library, urn=urn)
         if name:
@@ -200,10 +200,10 @@ class AddLibraryScript(Script):
             library.web_url = web
         if description:
             library.description = description
-        if adobe_short_name:
-            library.adobe_short_name = adobe_short_name
-        if adobe_shared_secret:
-            library.adobe_shared_secret = adobe_shared_secret
+        if short_name:
+            library.short_name = short_name
+        if shared_secret:
+            library.shared_secret = shared_secret
         if aliases:
             for alias in aliases:
                 get_one_or_create(self._db, LibraryAlias, library=library,

--- a/testing.py
+++ b/testing.py
@@ -111,8 +111,8 @@ class DatabaseTest(object):
         name = name or self._str
         library, ignore = get_one_or_create(self._db, Library, name=name)
         library.urn = self._str
-        library.adobe_short_name = self._str
-        library.adobe_shared_secret = self._str
+        library.short_name = self._str
+        library.shared_secret = self._str
         for place in service_areas:
             get_one_or_create(self._db, ServiceArea, library=library,
                               place=place)

--- a/tests/test_adobe_vendor_id.py
+++ b/tests/test_adobe_vendor_id.py
@@ -243,7 +243,7 @@ class TestVendorIDModel(VendorIDTest):
         # is created for one of the patrons.
         encoder = ShortClientTokenEncoder()
         short_client_token = encoder.encode(
-            self.library.adobe_short_name, self.library.adobe_shared_secret,
+            self.library.short_name, self.library.shared_secret,
             "patron alias"
         )
 
@@ -291,8 +291,8 @@ class TestVendorIDModel(VendorIDTest):
         # This token is correctly formed but the signature doesn't match.
         encoder = ShortClientTokenEncoder()
         bad_signature = encoder.encode(
-            self.library.adobe_short_name, 
-            self.library.adobe_shared_secret + "bad",
+            self.library.short_name, 
+            self.library.shared_secret + "bad",
             "patron alias"
         )
         eq_(None, None, (self.model.authdata_lookup, bad_signature))

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -269,15 +269,15 @@ class TestLibrary(DatabaseTest):
         expect = 'data:image/png;base64,' + base64.b64encode(nypl.logo)
         eq_(expect, nypl.logo_data_uri)
 
-    def test_adobe_short_name(self):
+    def test_short_name(self):
         lib = self._library("A Library")
-        lib.adobe_short_name = 'abcd'
-        eq_("ABCD", lib.adobe_short_name)
+        lib.short_name = 'abcd'
+        eq_("ABCD", lib.short_name)
         try:
-            lib.adobe_short_name = 'ab|cd'
+            lib.short_name = 'ab|cd'
             raise Error("Expected exception not raised.")
         except ValueError, e:
-            eq_('Adobe short name cannot contain the pipe character.',
+            eq_('Short name cannot contain the pipe character.',
                 e.message)
         
     def test_library_service_area(self):

--- a/tests/test_scripts.py
+++ b/tests/test_scripts.py
@@ -78,8 +78,8 @@ class TestAddLibraryScript(DatabaseTest):
                 '--web=https://nypl.org/',
                 '--opds=https://circulation.librarysimplified.org/',
                 '--description=Serving the five boroughs of New York, NY.',
-                '--adobe-short-name=NYNYPL',
-                '--adobe-shared-secret=12345',
+                '--short-name=NYNYPL',
+                '--shared-secret=12345',
         ]
         script = AddLibraryScript(self._db)
         script.run(cmd_args=args)
@@ -92,8 +92,8 @@ class TestAddLibraryScript(DatabaseTest):
         eq_(u"https://nypl.org/", library.web_url)
         eq_(u"https://circulation.librarysimplified.org/", library.opds_url)
         eq_(u"Serving the five boroughs of New York, NY.", library.description)
-        eq_(u"NYNYPL", library.adobe_short_name)
-        eq_(u"12345", library.adobe_shared_secret)
+        eq_(u"NYNYPL", library.short_name)
+        eq_(u"12345", library.shared_secret)
         
         [alias] = library.aliases
         eq_("NYPL", alias.name)

--- a/tests/test_short_client_token.py
+++ b/tests/test_short_client_token.py
@@ -119,8 +119,8 @@ class TestShortClientTokenDecoder(DatabaseTest):
         self.encoder = ShortClientTokenEncoder()
         self.decoder = ShortClientTokenDecoder(self.TEST_NODE_VALUE)
         self.library = self._library()
-        self.library.adobe_short_name='LIBRARY'
-        self.library.adobe_shared_secret='My shared secret'
+        self.library.short_name='LIBRARY'
+        self.library.shared_secret='My shared secret'
 
     def test_uuid(self):
         u = self.decoder.uuid()
@@ -135,7 +135,7 @@ class TestShortClientTokenDecoder(DatabaseTest):
         by one of its libraries.
         """
         short_client_token = self.encoder.encode(
-            self.library.adobe_short_name, self.library.adobe_shared_secret,
+            self.library.short_name, self.library.shared_secret,
             "Foreign Patron"
         )
 


### PR DESCRIPTION
This branch implements the shared secret and short name part of #24.

If the OPDS auth document has a public key, the register response will include a short name and shared secret in the library metadata. The shared secret is encrypted and base 64-encoded. A new secret will be generated if one doesn't exist yet or if the request includes the old secret. For now, the short name is generated randomly, and never changes once it exists.

I also renamed Library.adobe_short_name and Library.adobe_shared_secret since they could potentially be used for non-Adobe things, and I added the registry's vendor id to the metadata of its main OPDS catalog.