### PR TITLE
Use auth document

### DIFF
--- a/controller.py
+++ b/controller.py
@@ -258,7 +258,12 @@ class LibraryRegistryController(object):
         if auth_document.service_area:
             places, unknown, ambiguous = auth_document.service_area
             if unknown or ambiguous:
-                return INVALID_AUTH_DOCUMENT.detailed(_("The authentication document has an unknown or ambiguous service area."))
+                msgs = []
+                if unknown:
+                    msgs.append(str(_("The following service area was unknown: %(service_area)s.", service_area=json.dumps(unknown))))
+                if ambiguous:
+                    msgs.append(str(_("The following service area was ambiguous: %(service_area)s.", service_area=json.dumps(ambiguous))))
+                return INVALID_AUTH_DOCUMENT.detailed(" ".join(msgs))
             for place in places:
                 service_area = get_one_or_create(self._db, ServiceArea,
                                                  library_id=library.id,

--- a/controller.py
+++ b/controller.py
@@ -264,12 +264,14 @@ class LibraryRegistryController(object):
                 if ambiguous:
                     msgs.append(str(_("The following service area was ambiguous: %(service_area)s.", service_area=json.dumps(ambiguous))))
                 return INVALID_AUTH_DOCUMENT.detailed(" ".join(msgs))
+            place_ids = []
             for place in places:
                 service_area = get_one_or_create(self._db, ServiceArea,
                                                  library_id=library.id,
                                                  place_id=place.id)
+                place_ids.append(place.id)
             for service_area in library.service_areas:
-                if service_area.place_id not in [p.id for p in places]:
+                if service_area.place_id not in place_ids:
                     self._db.delete(service_area)
                     
         catalog = OPDSCatalog.library_catalog(library)

--- a/model.py
+++ b/model.py
@@ -653,6 +653,10 @@ class Place(Base):
         return qu
 
     @classmethod
+    def lookup_one_by_name(cls, _db, name, place_type=None):
+        return cls.lookup_by_name(_db, name, place_type).one()
+
+    @classmethod
     def name_parts(cls, name):
         """Split a nested geographic name into parts.
 

--- a/model.py
+++ b/model.py
@@ -482,14 +482,6 @@ class Library(Base):
         else:
             return 'urn:' + self.urn
     
-    @property
-    def logo_data_uri(self):
-        """Return the logo as a data: URI."""
-        if not self.logo:
-            return None
-        return "data:image/png;base64,%s" % base64.b64encode(self.logo)
-
-
 class LibraryAlias(Base):
 
     """An alternate name for a library."""

--- a/model.py
+++ b/model.py
@@ -577,7 +577,7 @@ class Place(Base):
     # The geography of the place itself. It is stored internally as a
     # geometry, which means we have to cast to Geography when doing
     # calculations.
-    geometry = Column(Geometry(srid=4326))
+    geometry = Column(Geometry(srid=4326), nullable=True)
 
     aliases = relationship("PlaceAlias", backref='place')
 

--- a/opds.py
+++ b/opds.py
@@ -86,7 +86,7 @@ class OPDSCatalog(object):
 
         if library.logo:
             cls.add_image_to_catalog(catalog, rel=cls.THUMBNAIL_REL,
-                                     href=library.logo_data_uri,
+                                     href=library.logo,
                                      type="image/png")
 
         return catalog

--- a/requirements.txt
+++ b/requirements.txt
@@ -13,3 +13,4 @@ sqlalchemy
 uwsgi
 Flask-Babel
 pycryptodome
+pillow

--- a/testing.py
+++ b/testing.py
@@ -8,6 +8,7 @@ from geoalchemy2 import Geometry
 from sqlalchemy import func
 from sqlalchemy.orm.session import Session
 from sqlalchemy.sql.expression import cast
+from StringIO import StringIO
 
 from config import Configuration
 from model import (
@@ -271,6 +272,10 @@ class DummyHTTPResponse(object):
         self.status_code = status_code
         self.headers = headers
         self.content = content
+
+    @property
+    def raw(self):
+        return StringIO(self.content)
 
 class DummyHTTPClient(object):
 

--- a/tests/test_authentication_document.py
+++ b/tests/test_authentication_document.py
@@ -8,6 +8,7 @@ from nose.tools import (
 )
 from sqlalchemy.orm.exc import (
     MultipleResultsFound,
+    NoResultFound,
 )
 from authentication_document import AuthenticationDocument
 
@@ -23,39 +24,45 @@ class MockPlace(object):
     # Used to indicate coverage through the universe or through a
     # country.
     EVERYWHERE = object()
-    
-    def __init__(self, by_name=None, is_inside=None):
-        self.by_name = by_name or dict()
-        self.is_inside = is_inside or dict()
 
-    def lookup_by_name(self, _db, name, place_type):
-        place = self.by_name.get(name)
-        if place is self.AMBIGUOUS:
+    by_name = dict()
+
+    def __init__(self, inside=None):
+        self.inside = inside or dict()
+
+    @classmethod
+    def lookup_one_by_name(cls, _db, name, place_type):
+        place = cls.by_name.get(name)
+        if place is cls.AMBIGUOUS:
             raise MultipleResultsFound()
+        if place is None:
+            raise NoResultFound()
         return place
         
-    def lookup_inside(self, _db, name, must_be_inside):
-        places_inside = self.is_inside.get(must_be_inside)
-        place = places_inside.get(name)
+    def lookup_inside(self, name):
+        place = self.inside.get(name)
         if place is self.AMBIGUOUS:
             raise MultipleResultsFound()
+        if place is None:
+            raise NoResultFound()
         return place
 
-    def everywhere(self, _db):
-        return self.EVERYWHERE
+    @classmethod
+    def everywhere(cls, _db):
+        return cls.EVERYWHERE
 
 class TestParseCoverage(object):
 
     EVERYWHERE = AuthenticationDocument.COVERAGE_EVERYWHERE
     
-    def parse_places(self, mock_place, coverage_object, expected_places=None,
+    def parse_places(self, coverage_object, expected_places=None,
                      expected_unknown=None, expected_ambiguous=None):
         """Call AuthenticationDocument.parse_coverage. Verify that the parsed
         list of places, as well as the dictionaries of unknown and
         ambiguous place names, are as expected.
         """
         place_objs, unknown, ambiguous = AuthDoc.parse_coverage(
-            None, coverage_object, mock_place
+            None, coverage_object, MockPlace
         )
         empty = defaultdict(list)
         expected_places = expected_places or []
@@ -66,59 +73,53 @@ class TestParseCoverage(object):
         eq_(expected_ambiguous, ambiguous)
         
     def test_universal_coverage(self):
-        """Test an authentication document that says a library covers the
-        whole universe.
-        """
-        places = MockPlace()
+        # Test an authentication document that says a library covers the
+        # whole universe.
         self.parse_places(
-            places, self.EVERYWHERE, [MockPlace.EVERYWHERE]
+            self.EVERYWHERE, [MockPlace.EVERYWHERE]
         )
 
     def test_entire_country(self):
-        """Test an authentication document that says a library covers an
-        entire country.
-        """
-        places = MockPlace({"US": "United States"})
+        # Test an authentication document that says a library covers an
+        # entire country.
+        us = MockPlace()
+        MockPlace.by_name["US"] = us
         self.parse_places(
-            places,
             {"US": self.EVERYWHERE },
-            expected_places=["United States"]
+            expected_places=[us]
         )
 
     def test_ambiguous_country(self):
-        """Test the unlikely scenario where an authentication document says a
-        library covers an entire country, but it's ambiguous which
-        country is being referred to.
-        """
+        # Test the unlikely scenario where an authentication document says a
+        # library covers an entire country, but it's ambiguous which
+        # country is being referred to.
 
-        places = MockPlace(
-            {"CA": "Canada", "Europe I think?": MockPlace.AMBIGUOUS}
-        )
+        canada = MockPlace()
+        MockPlace.by_name["CA"] = canada
+        MockPlace.by_name["Europe I think?"] = MockPlace.AMBIGUOUS
         self.parse_places(
-            places, 
             {"Europe I think?": self.EVERYWHERE, "CA": self.EVERYWHERE },
-            expected_places=["Canada"],
+            expected_places=[canada],
             expected_ambiguous={"Europe I think?": self.EVERYWHERE}
         )
 
     def test_unknown_country(self):
-        """Test an authentication document that says a library covers an
-        entire country, but the library registry doesn't know anything about
-        that country's geography.
-        """
+        # Test an authentication document that says a library covers an
+        # entire country, but the library registry doesn't know anything about
+        # that country's geography.
 
-        places = MockPlace({"CA": "Canada"})
+        canada = MockPlace()
+        MockPlace.by_name["CA"] = canada
         self.parse_places(
-            places, 
             {"Memory Alpha": self.EVERYWHERE, "CA": self.EVERYWHERE },
-            expected_places=["Canada"],
+            expected_places=[canada],
             expected_unknown={"Memory Alpha": self.EVERYWHERE}
         )
 
     def test_places_within_country(self):
-        """Test an authentication document that says a library
-        covers one or more places within a country.
-        """
+        # Test an authentication document that says a library
+        # covers one or more places within a country.
+
         # This authentication document covers two places called
         # "San Francisco" (one in the US and one in Mexico) as well as a
         # place called "Mexico City" in Mexico.
@@ -127,39 +128,43 @@ class TestParseCoverage(object):
         # place name (it's supposed to always be a list), but our
         # parser can handle it.
         doc = {"US": "San Francisco", "MX": ["San Francisco", "Mexico City"]}
-        
-        is_inside = {
-            "US": {"San Francisco": "object1", "San Jose": "object2"},
-            "MX": {"San Francisco": "object3", "Mexico City": "object4"}
-        }
-        places = MockPlace(is_inside=is_inside)
+
+        place1 = MockPlace()
+        place2 = MockPlace()
+        place3 = MockPlace()
+        place4 = MockPlace()
+        us = MockPlace(inside={"San Francisco": place1, "San Jose": place2})
+        mx = MockPlace(inside={"San Francisco": place3, "Mexico City": place4})
+        MockPlace.by_name["US"] = us
+        MockPlace.by_name["MX"] = mx
 
         # AuthenticationDocument.parse_coverage is able to turn those
         # three place names into place objects.
         self.parse_places(
-            places, doc,
-            expected_places=["object1", "object3", "object4"]
+            doc,
+            expected_places=[place1, place3, place4]
         )
 
     def test_ambiguous_place_within_country(self):
-        """Test an authentication document that names an ambiguous
-        place within a country.
-        """
-        is_inside = {"US": {"Springfield": MockPlace.AMBIGUOUS}}
-        places = MockPlace(is_inside=is_inside)
+        # Test an authentication document that names an ambiguous
+        # place within a country.
+        us = MockPlace(inside={"Springfield": MockPlace.AMBIGUOUS})
+        MockPlace.by_name["US"] = us
+
         self.parse_places(
-            places, {"US": ["Springfield"]},
+            {"US": ["Springfield"]},
             expected_ambiguous={"US": ["Springfield"]}
         )
 
     def test_unknown_place_within_country(self):
-        """Test an authentication document that names an unknown
-        place within a country.
-        """
-        is_inside = {"US": {"San Francisco": "object1"}}
-        places = MockPlace(is_inside=is_inside)
+        # Test an authentication document that names an unknown
+        # place within a country.
+        sf = MockPlace()
+        us = MockPlace(inside={"San Francisco": sf})
+        MockPlace.by_name["US"] = us
+
         self.parse_places(
-            places, {"US": "Nowheresville"},
+            {"US": "Nowheresville"},
             expected_unknown={"US": ["Nowheresville"]}
         )
 
@@ -221,8 +226,8 @@ class TestLinkExtractor(object):
         
         # In the absence of specific information, it's assumed the
         # OPDS server is open to everyone.
-        eq_(everywhere, parsed.service_area)
-        eq_(everywhere, parsed.focus_area)
+        eq_(([everywhere], [], []), parsed.service_area)
+        eq_(([everywhere], [], []), parsed.focus_area)
         eq_([parsed.PUBLIC_AUDIENCE], parsed.audiences)
 
         eq_(None, parsed.id)

--- a/tests/test_controller.py
+++ b/tests/test_controller.py
@@ -444,6 +444,17 @@ class TestLibraryRegistryController(ControllerTest):
             http_client.queue_response(401, content=json.dumps(auth_document))
             response = self.controller.register(do_get=http_client.do_get)
             eq_(INVALID_AUTH_DOCUMENT.uri, response.uri)
+            eq_("The following service area was unknown: {\"US\": [\"Somewhere\"]}.", response.detail)
+
+            # This feed has an ambiguous service area.
+            auth_document = {
+                "name": "A Library",
+                "service_area": {"US": ["Manhattan"]},
+            }
+            http_client.queue_response(401, content=json.dumps(auth_document))
+            response = self.controller.register(do_get=http_client.do_get)
+            eq_(INVALID_AUTH_DOCUMENT.uri, response.uri)
+            eq_("The following service area was ambiguous: {\"US\": [\"Manhattan\"]}.", response.detail)
 
             # This feed links to a broken logo image.
             http_client.queue_response(500)
@@ -456,7 +467,6 @@ class TestLibraryRegistryController(ControllerTest):
             http_client.queue_response(401, content=json.dumps(auth_document))
             response = self.controller.register(do_get=http_client.do_get)
             eq_(INVALID_AUTH_DOCUMENT.uri, response.uri)
-
 
 
 

--- a/tests/test_controller.py
+++ b/tests/test_controller.py
@@ -250,11 +250,13 @@ class TestLibraryRegistryController(ControllerTest):
                 ("url", "http://circmanager.org"),
             ])
 
+            image_data = '\x89PNG\r\n\x1a\n\x00\x00\x00\rIHDR\x00\x00\x00\x01\x00\x00\x00\x01\x01\x03\x00\x00\x00%\xdbV\xca\x00\x00\x00\x06PLTE\xffM\x00\x01\x01\x01\x8e\x1e\xe5\x1b\x00\x00\x00\x01tRNS\xcc\xd24V\xfd\x00\x00\x00\nIDATx\x9cc`\x00\x00\x00\x02\x00\x01H\xaf\xa4q\x00\x00\x00\x00IEND\xaeB`\x82'
+            http_client.queue_response(200, content=image_data)
             auth_document = {
                 "name": "A Library",
                 "service_description": "My feed requires authentication",
                 "links": {
-                    "logo": { "href": "data:image/png;newimagedata" },
+                    "logo": { "href": "http://example.com/logo.png", "type": "image/png" },
                 },
                 "service_area": { "US": "Connecticut" },
             }
@@ -268,12 +270,12 @@ class TestLibraryRegistryController(ControllerTest):
             eq_("A Library", library.name)
             eq_("My feed requires authentication", library.description)
             eq_(None, library.web_url)
-            eq_("data:image/png;newimagedata", library.logo)
+            eq_("data:image/png;base64,%s" % base64.b64encode(image_data), library.logo)
             # Commit to update library.service_areas.
             self._db.commit()
             [service_area] = library.service_areas
             eq_(self.connecticut_state.id, service_area.place_id)
-            eq_(["http://circmanager.org"], http_client.requests[1:])
+            eq_(["http://circmanager.org", "http://example.com/logo.png"], http_client.requests[1:])
 
             catalog = json.loads(response.data)
             eq_("A Library", catalog['metadata']['title'])
@@ -290,7 +292,7 @@ class TestLibraryRegistryController(ControllerTest):
             response = self.controller.register(do_get=http_client.do_get)
             eq_(200, response.status_code)
             eq_("My feed links to the auth document", library.description)
-            eq_(["http://circmanager.org", "http://circmanager.org/auth"], http_client.requests[2:])
+            eq_(["http://circmanager.org", "http://circmanager.org/auth"], http_client.requests[3:])
 
             auth_document = {
                 "name": "A Library",
@@ -303,7 +305,7 @@ class TestLibraryRegistryController(ControllerTest):
             response = self.controller.register(do_get=http_client.do_get)
             eq_(200, response.status_code)
             eq_("My feed links to the shelf, which requires auth", library.description)
-            eq_(["http://circmanager.org", "http://circmanager.org/shelf"], http_client.requests[4:])
+            eq_(["http://circmanager.org", "http://circmanager.org/shelf"], http_client.requests[5:])
             
             auth_document = {
                 "name": "A Library",
@@ -318,7 +320,7 @@ class TestLibraryRegistryController(ControllerTest):
             response = self.controller.register(do_get=http_client.do_get)
             eq_(200, response.status_code)
             eq_("My feed links to a shelf which links to the auth document", library.description)
-            eq_(["http://circmanager.org", "http://circmanager.org/shelf", "http://circmanager.org/auth"], http_client.requests[6:])
+            eq_(["http://circmanager.org", "http://circmanager.org/shelf", "http://circmanager.org/auth"], http_client.requests[7:])
 
             # The request did not include the old secret, so the secret wasn't changed.
             eq_(old_secret, library.shared_secret)
@@ -442,6 +444,19 @@ class TestLibraryRegistryController(ControllerTest):
             http_client.queue_response(401, content=json.dumps(auth_document))
             response = self.controller.register(do_get=http_client.do_get)
             eq_(INVALID_AUTH_DOCUMENT.uri, response.uri)
+
+            # This feed links to a broken logo image.
+            http_client.queue_response(500)
+            auth_document = {
+                "name": "A Library",
+                "links": {
+                    "logo": { "href": "http://example.com/logo.png", "type": "image/png" },
+                },
+            }
+            http_client.queue_response(401, content=json.dumps(auth_document))
+            response = self.controller.register(do_get=http_client.do_get)
+            eq_(INVALID_AUTH_DOCUMENT.uri, response.uri)
+
 
 
 

--- a/tests/test_controller.py
+++ b/tests/test_controller.py
@@ -197,8 +197,8 @@ class TestLibraryRegistryController(ControllerTest):
                 "name": "A Library",
                 "service_description": "Description",
                 "links": {
-                    "alternate": { "href": "http://alibrary.org" },
-                    "logo": { "href": "image data" },
+                    "alternate": { "href": "http://alibrary.org", "type": "text/html" },
+                    "logo": { "href": "data:image/png;imagedata" },
                 },
                 "public_key": {
                     "type": "RSA",
@@ -216,7 +216,7 @@ class TestLibraryRegistryController(ControllerTest):
             eq_("A Library", library.name)
             eq_("Description", library.description)
             eq_("http://alibrary.org", library.web_url)
-            eq_("image data", library.logo)
+            eq_("data:image/png;imagedata", library.logo)
 
             eq_(["http://circmanager.org"], http_client.requests)
 
@@ -250,7 +250,7 @@ class TestLibraryRegistryController(ControllerTest):
                 "name": "A Library",
                 "service_description": "My feed requires authentication",
                 "links": {
-                    "logo": { "href": "new image data" },
+                    "logo": { "href": "data:image/png;newimagedata" },
                 }
             }
             http_client.queue_response(401, content=json.dumps(auth_document))
@@ -263,7 +263,7 @@ class TestLibraryRegistryController(ControllerTest):
             eq_("A Library", library.name)
             eq_("My feed requires authentication", library.description)
             eq_(None, library.web_url)
-            eq_("new image data", library.logo)
+            eq_("data:image/png;newimagedata", library.logo)
             eq_(["http://circmanager.org"], http_client.requests[1:])
 
             catalog = json.loads(response.data)
@@ -326,8 +326,8 @@ class TestLibraryRegistryController(ControllerTest):
                 "name": "A Library",
                 "service_description": "Description",
                 "links": {
-                    "alternate": { "href": "http://alibrary.org" },
-                    "logo": { "href": "image data" },
+                    "alternate": { "href": "http://alibrary.org", "type": "text/html" },
+                    "logo": { "href": "data:image/png;imagedata" },
                 },
                 "public_key": {
                     "type": "RSA",
@@ -363,8 +363,8 @@ class TestLibraryRegistryController(ControllerTest):
                 "name": "A Library",
                 "service_description": "Description",
                 "links": {
-                    "alternate": { "href": "http://alibrary.org" },
-                    "logo": { "href": "image data" },
+                    "alternate": { "href": "http://alibrary.org", "type": "text/html" },
+                    "logo": { "href": "data:image/png;imagedata" },
                 },
                 "public_key": {
                     "type": "RSA",

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -261,13 +261,6 @@ class TestLibrary(DatabaseTest):
         eq_("urn:foo", nypl.urn_uri)
         nypl.urn = 'urn:bar'
         eq_('urn:bar', nypl.urn_uri)
-        
-    def test_logo_data_uri(self):
-        """The library's logo can be converted into a data: URI."""
-        nypl = self._library("New York Public Library")
-        nypl.logo = "Fake logo"
-        expect = 'data:image/png;base64,' + base64.b64encode(nypl.logo)
-        eq_(expect, nypl.logo_data_uri)
 
     def test_short_name(self):
         lib = self._library("A Library")

--- a/tests/test_opds.py
+++ b/tests/test_opds.py
@@ -66,7 +66,7 @@ class TestOPDSCatalog(DatabaseTest):
         eq_(OPDSCatalog.CATALOG_REL, opds['rel'])
         eq_(OPDSCatalog.OPDS_1_TYPE, opds['type'])
 
-        eq_(library.logo_data_uri, logo['href'])
+        eq_(library.logo, logo['href'])
         eq_(OPDSCatalog.THUMBNAIL_REL, logo['rel'])
         eq_("image/png", logo['type'])
 


### PR DESCRIPTION
This branch converts the registration controller method to parse the OPDS auth document with AuthenticationDocument, and adds support for registering service areas and logo links.

AuthenticationDocument.parse_coverage wasn't working with the Place class, so I had to refactor it a bit and make MockPlace more like Place.