### PR TITLE
Create a 'qa' feed (as distinct from the 'live' feed) containing only items in the 'approved' stage.

### DIFF
--- a/app.py
+++ b/app.py
@@ -55,6 +55,13 @@ def nearby():
         originating_ip()
     )
 
+@app.route('/qa')
+@returns_problem_detail
+def nearby_qa():
+    return app.library_registry.registry_controller.nearby(
+        originating_ip(), qa=True
+    )
+
 @app.route("/register", methods=["POST"])
 @returns_problem_detail
 def register():
@@ -65,6 +72,13 @@ def register():
 def search():
     return app.library_registry.registry_controller.search(
         originating_ip()
+    )
+
+@app.route('/qa/search')
+@returns_problem_detail
+def search_qa():
+    return app.library_registry.registry_controller.search(
+        originating_ip(), qa=True
     )
 
 @app.route('/heartbeat')

--- a/app.py
+++ b/app.py
@@ -59,7 +59,7 @@ def nearby():
 @returns_problem_detail
 def nearby_qa():
     return app.library_registry.registry_controller.nearby(
-        originating_ip(), qa=True
+        originating_ip(), live=False
     )
 
 @app.route("/register", methods=["POST"])
@@ -78,7 +78,7 @@ def search():
 @returns_problem_detail
 def search_qa():
     return app.library_registry.registry_controller.search(
-        originating_ip(), qa=True
+        originating_ip(), live=False
     )
 
 @app.route('/heartbeat')

--- a/opds.py
+++ b/opds.py
@@ -44,7 +44,8 @@ class OPDSCatalog(object):
         image = dict(**kwargs)
         catalog.setdefault("images", []).append(image)
 
-    def __init__(self, _db, title, url, libraries, annotator=None):
+    def __init__(self, _db, title, url, libraries, annotator=None,
+                 live=True):
         """Turn a list of libraries into a catalog."""
         if not annotator:
             annotator = Annotator()
@@ -57,7 +58,7 @@ class OPDSCatalog(object):
             if not isinstance(library, tuple):
                 library = (library,)
             self.catalog["catalogs"].append(self.library_catalog(*library))
-        annotator.annotate_catalog(self)
+        annotator.annotate_catalog(self, live=live)
 
     @classmethod
     def library_catalog(cls, library, distance=None):

--- a/tests/test_opds.py
+++ b/tests/test_opds.py
@@ -16,7 +16,7 @@ class TestOPDSCatalog(DatabaseTest):
         l1 = self._library("The New York Public Library")
         l2 = self._library("Brooklyn Public Library")
         class TestAnnotator(object):
-            def annotate_catalog(self, catalog_obj):
+            def annotate_catalog(self, catalog_obj, live=True):
                 catalog_obj.catalog['metadata']['random'] = "Random text inserted by annotator."
                 
         catalog = OPDSCatalog(


### PR DESCRIPTION
This branch introduces an alternate feed at /qa which shows only items in the "approved" stage. (The default feed shows only items in the "live" stage.) This is done with alternate inputs into the `nearby` and `search` controllers.