### PR TITLE
Introduce different types of ServiceArea, such as 'focus area'

### DIFF
--- a/authentication_document.py
+++ b/authentication_document.py
@@ -116,7 +116,7 @@ class AuthenticationDocument(object):
             # parse anything.
             place_objs.append(place_class.everywhere(_db))
             coverage = dict()
-            
+
         for country, places in coverage.items():
             try:
                 country_obj = place_class.lookup_one_by_name(
@@ -286,9 +286,9 @@ class AuthenticationDocument(object):
                 msgs.append(str(_("The following service area was unknown: %(service_area)s.", service_area=json.dumps(unknown))))
             if ambiguous:
                 msgs.append(str(_("The following service area was ambiguous: %(service_area)s.", service_area=json.dumps(ambiguous))))
+            _db.rollback()
             return INVALID_AUTH_DOCUMENT.detailed(" ".join(msgs))
 
-        place_ids = []
         for place in places:
             service_area, is_new = get_one_or_create(
                 _db, ServiceArea, library_id=library.id,

--- a/model.py
+++ b/model.py
@@ -241,7 +241,6 @@ class Library(Base):
         "DelegatedPatronIdentifier", backref='library'
     )
     service_areas = relationship('ServiceArea', backref='library')
-    focus_areas = relationship('ServiceArea', backref='library_focus')
     
     __table_args__ = (
         UniqueConstraint('urn'),

--- a/model.py
+++ b/model.py
@@ -241,7 +241,8 @@ class Library(Base):
         "DelegatedPatronIdentifier", backref='library'
     )
     service_areas = relationship('ServiceArea', backref='library')
-
+    focus_areas = relationship('ServiceArea', backref='library_focus')
+    
     __table_args__ = (
         UniqueConstraint('urn'),
         UniqueConstraint('short_name'),
@@ -557,8 +558,19 @@ class ServiceArea(Base):
         Integer, ForeignKey('places.id'), index=True
     )
 
+    # A library may have a ServiceArea because people in that area are
+    # eligible for service, or because the library specifically
+    # focuses on that area.
+    ELIGIBILITY = 'eligibility'
+    FOCUS = 'focus'
+    servicearea_type_enum = Enum(
+        ELIGIBILITY, FOCUS, name='servicearea_type'
+    )
+    type = Column(servicearea_type_enum,
+                  index=True, nullable=False, default=ELIGIBILITY)
+    
     __table_args__ = (
-        UniqueConstraint('library_id', 'place_id'),
+        UniqueConstraint('library_id', 'place_id', 'type'),
     )
     
 


### PR DESCRIPTION
This branch introduces the concept of 'focus area' by adding a `type` field to ServiceArea. The type of ServiceArea we've been dealing with up to this point has `type="eligibility"`, and the new type has `type="focus"`.

A Library advertises its focus area by naming specific places in its Authentication For OPDS document.  I refactored some code from the controller into `AuthenticationDocument` and made it work both for `service_area` and `focus_area`.

Any ServiceArea indicates that people in a certain Place are served by the Library, but the "focus area" indicates a Place that is the Library's primary concern. By default, a Library's focus area is the same as its service area.

We should be prepared for a library to have the same Place as two different ServiceAreas with different types, but in the most common case where this would happen (the library has a service area but no focus area) we avoid this by only registering the focus area.