### PR TITLE
Store booleans for 'anonymous access' and 'online registration'

### DIFF
--- a/authentication_document.py
+++ b/authentication_document.py
@@ -65,7 +65,7 @@ class AuthenticationDocument(object):
         self.website = self.extract_link(
             rel="alternate", require_type="text/html"
         )
-        self.registration = self.extract_link(rel="register")
+        self.online_registration = self.extract_link(rel="register") is not None
         self.root = self.extract_link(
             rel="start",
             prefer_type="application/atom+xml;profile=opds-catalog"
@@ -224,11 +224,17 @@ class AuthenticationDocument(object):
         :param library: A Library.
         :return: A ProblemDetail if there's a problem, otherwise None.
         """
+        library.name = self.title
+        library.description = self.service_description
+        library.online_registration = self.online_registration
+        library.anonymous_access = self.anonymous_access
+
         problem = self.update_audiences(library)
         if not problem:
             problem = self.update_service_areas(library)
         if not problem:
             problem = self.update_collection_size(library)
+
         return problem
         
     def update_audiences(self, library):

--- a/controller.py
+++ b/controller.py
@@ -284,9 +284,6 @@ class LibraryRegistryController(object):
             create_method_kwargs=dict(stage=Library.REGISTERED)
         )
 
-        library.name = auth_document.title
-        library.description = auth_document.service_description
-
         if auth_document.website:
             url = auth_document.website.get("href")
             if url:

--- a/model.py
+++ b/model.py
@@ -11,6 +11,7 @@ import warnings
 from psycopg2.extensions import adapt as sqlescape
 from sqlalchemy import (
     Binary,
+    Boolean,
     Column,
     DateTime,
     Enum,
@@ -228,6 +229,13 @@ class Library(Base):
         REGISTERED, APPROVED, REJECTED, LIVE, name='library_stage'
     )
     stage = Column(stage_enum, index=True, nullable=False, default=REGISTERED)
+
+    # Can people get books from this library without authenticating?
+    anonymous_access = Column(Boolean, default=False)
+
+    # Can eligible people get credentials for this library through
+    # an online registration process?
+    online_registration = Column(Boolean, default=False)
     
     # To issue Short Client Tokens for this library, the registry must share a
     # short name and a secret with them.

--- a/tests/test_authentication_document.py
+++ b/tests/test_authentication_document.py
@@ -245,7 +245,7 @@ class TestLinkExtractor(object):
         eq_(None, parsed.collection_size)
         eq_(None, parsed.public_key)
         eq_(None, parsed.website)
-        eq_(None, parsed.registration)
+        eq_(False, parsed.online_registration)
         eq_(None, parsed.root)
         eq_({}, parsed.links)
         eq_(None, parsed.logo)
@@ -288,8 +288,7 @@ class TestLinkExtractor(object):
         eq_("a public key", parsed.public_key)
         eq_({u'href': u'http://ansonialibrary.org', u'type': u'text/html'},
             parsed.website)
-        eq_({"href": "http://example.com/get-a-card/", "type": "text/html"},
-            parsed.registration)
+        eq_(True, parsed.online_registration)
         eq_({"href": "http://opds.example.com/", "type": "application/atom+xml;profile=opds-catalog"}, parsed.root)
         eq_("data:image/png;base64,some-image-data", parsed.logo)
         eq_(None, parsed.logo_link)

--- a/tests/test_controller.py
+++ b/tests/test_controller.py
@@ -268,9 +268,11 @@ class TestLibraryRegistryController(ControllerTest):
                 "id": "http://circmanager.org",
                 "name": "A Library",
                 "service_description": "Description",
+                "type": ["https://librarysimplified.org/rel/auth/anonymous"],
                 "links": {
                     "alternate": { "href": "http://alibrary.org", "type": "text/html" },
                     "logo": { "href": "data:image/png;imagedata" },
+                    "register": { "href": "http://alibrary.org/new-account" }
                 },
                 "service_area": { "US": "Kansas" },
                 "collection_size": 100,
@@ -295,6 +297,8 @@ class TestLibraryRegistryController(ControllerTest):
             eq_("data:image/png;imagedata", library.logo)
             eq_(Library.REGISTERED, library.stage)
 
+            eq_(True, library.anonymous_access)
+            
             [collection_summary] = library.collections
             eq_(None, collection_summary.language)
             eq_(100, collection_summary.size)

--- a/tests/test_controller.py
+++ b/tests/test_controller.py
@@ -298,6 +298,7 @@ class TestLibraryRegistryController(ControllerTest):
             eq_(Library.REGISTERED, library.stage)
 
             eq_(True, library.anonymous_access)
+            eq_(True, library.online_registration)
             
             [collection_summary] = library.collections
             eq_(None, collection_summary.language)


### PR DESCRIPTION
This branch closes out https://github.com/NYPL-Simplified/library_registry/issues/39 by storing the last two pieces of information we need from the authentication document: whether anonymous access is allowed and whether you can get library credentials through an entirely online process.