### PR TITLE
Compare SCTs with low-numbered expiration dates against a new epoch.

### DIFF
--- a/model.py
+++ b/model.py
@@ -1284,8 +1284,23 @@ class ShortClientTokenDecoder(ShortClientTokenTool):
             )
 
         # Don't bother checking an expired token.
+        #
+        # Currently there are two ways of specifying a token's
+        # expiration date: as a number of minutes since self.SCT_EPOCH
+        # or as a number of seconds since self.JWT_EPOCH.
         now = datetime.datetime.utcnow()
-        expiration = self.EPOCH + datetime.timedelta(seconds=expiration)
+
+        # NOTE: The JWT code needs to be removed by the year 4869 or
+        # this will break.
+        if expiration < 1500000000:
+            # This is a number of minutes since the start of 2017.
+            expiration = self.SCT_EPOCH + datetime.timedelta(
+                minutes=expiration
+            )
+        else:
+            # This is a number of seconds since the start of 1970.
+            expiration = self.JWT_EPOCH + datetime.timedelta(seconds=expiration)
+
         if expiration < now:
             raise ValueError(
                 "Token %s expired at %s (now is %s)." % (

--- a/tests/test_short_client_token.py
+++ b/tests/test_short_client_token.py
@@ -176,7 +176,7 @@ class TestShortClientTokenDecoder(DatabaseTest):
 
         # The patron identifier must not be blank.
         assert_raises_regexp(
-            ValueError, 'Token library|1234| has empty patron identifier',
+            ValueError, 'Token library\|1234\| has empty patron identifier',
             m, self._db, "library|1234|", "signature"
         )
         
@@ -190,10 +190,21 @@ class TestShortClientTokenDecoder(DatabaseTest):
         # The token must not have expired.
         assert_raises_regexp(
             ValueError,
-            'Token mylibrary|1234|patron expired at 1970-01-01 00:20:34',
+            'Token library\|1234\|patron expired at 2017-01-01 20:34:00',
             m, self._db, "library|1234|patron", "signature"
         )
 
+        # (Even though the expiration number here is much higher, this
+        # token is also expired, because the expiration date
+        # calculation for an old-style token starts at a different
+        # epoch and treats the expiration number as seconds rather
+        # than minutes.)
+        assert_raises_regexp(
+            ValueError,
+            'Token library\|1500000000\|patron expired at 2017-07-14 02:40:00',
+            m, self._db, "library|1500000000|patron", "signature"
+        )
+        
         # Finally, the signature must be valid.
         assert_raises_regexp(
             ValueError, 'Invalid signature for',


### PR DESCRIPTION
This fixes https://github.com/NYPL-Simplified/circulation/issues/648 by shaving several characters off the 'username' portion of the short client token.