### PR TITLE
Don't choke when unable to decode the password portion of a Short Client Token.

### DIFF
--- a/model.py
+++ b/model.py
@@ -1250,7 +1250,10 @@ class ShortClientTokenDecoder(ShortClientTokenTool):
         """Decode a short client token that has already been split into
         two parts.
         """
-        signature = self.adobe_base64_decode(password)
+        try:
+            signature = self.adobe_base64_decode(password)
+        except Exception, e:
+            raise ValueError("Invalid password: %s" % password)
         return self._decode(_db, username, signature)
 
     def _decode(self, _db, token, supposed_signature):

--- a/tests/test_short_client_token.py
+++ b/tests/test_short_client_token.py
@@ -239,3 +239,8 @@ class TestShortClientTokenDecoder(DatabaseTest):
         # test failure, it ran successfully.
         eq_(True, self.decoder.test_code_ran)        
 
+        assert_raises_regexp(
+            ValueError, "Invalid password",
+            self.decoder.decode_two_part,
+            self._db, "username", "I am not a real encoded signature"
+        )


### PR DESCRIPTION
This was the only problem I found when testing the library registry's ability to delegate Adobe ID checks to some other server.