### PR TITLE
Script that sets a library's coverage area

### DIFF
--- a/bin/set_coverage_area
+++ b/bin/set_coverage_area
@@ -1,0 +1,9 @@
+#!/usr/bin/env python
+"""Set the coverage area for a library."""
+import os
+import sys
+bin_dir = os.path.split(__file__)[0]
+package_dir = os.path.join(bin_dir, "..")
+sys.path.append(os.path.abspath(package_dir))
+from scripts import SetCoverageAreaScript
+SetCoverageAreaScript().run()

--- a/scripts.py
+++ b/scripts.py
@@ -164,6 +164,9 @@ class AddLibraryScript(Script):
     def arg_parser(cls):
         parser = super(AddLibraryScript, cls).arg_parser()
         parser.add_argument(
+            '--name', help='Official name of the library', required=True
+        )
+        parser.add_argument(
             '--urn',
             help="URN used in the library's Authentication for OPDS document.",
             required=True

--- a/scripts.py
+++ b/scripts.py
@@ -1,6 +1,7 @@
 from nose.tools import set_trace
 import argparse
 import base64
+import json
 import logging
 import os
 import re
@@ -21,6 +22,7 @@ from model import (
 )
 from config import Configuration
 from adobe_vendor_id import AdobeVendorIDClient
+from authentication_document import AuthenticationDocument
 
 class Script(object):
 
@@ -80,6 +82,18 @@ class Script(object):
     def load_configuration(self):
         if not Configuration.instance:
             Configuration.load()
+
+
+class LibraryScript(Script):
+    """A script that operates on one specific library."""
+
+    @classmethod
+    def arg_parser(cls):
+        parser = super(LibraryScript, cls).arg_parser()
+        parser.add_argument(
+            '--library', help='Official name of the library', required=True
+        )
+        return parser
 
             
 class LoadPlacesScript(Script):
@@ -150,9 +164,6 @@ class AddLibraryScript(Script):
     def arg_parser(cls):
         parser = super(AddLibraryScript, cls).arg_parser()
         parser.add_argument(
-            '--name', help='Official name of the library', required=True
-        )
-        parser.add_argument(
             '--urn',
             help="URN used in the library's Authentication for OPDS document.",
             required=True
@@ -215,6 +226,60 @@ class AddLibraryScript(Script):
                     self._db, ServiceArea, library=library, place=place
                 )
         self._db.commit()
+
+
+class SetCoverageAreaScript(LibraryScript):
+
+    @classmethod
+    def arg_parser(cls):
+        parser = super(SetCoverageAreaScript, cls).arg_parser()
+        parser.add_argument(
+            '--service-area',
+            help="JSON document describing the library's service area. If no value is specified, it is assumed to be the same as --focus-area."
+        )
+        parser.add_argument(
+            '--focus-area',
+            help="JSON document describing the library's focus area. If no value is specified, it is assumed to be the same as --service-area."
+        )
+        return parser
+
+    def run(self, cmd_args=None, place_class=Place):
+        parsed = self.parse_command_line(self._db, cmd_args)
+
+        library = get_one(self._db, Library, name=parsed.library)
+        if not library:
+            raise Exception("No library with name %r" % parsed.library)
+
+        if not parsed.service_area and not parsed.focus_area:
+            raise Exception("Either --service-area or --focus-area must be specified.")
+        service_area = focus_area = None
+
+        def _load_area(x):
+            if not x:
+                return None
+            try:
+                x = json.loads(x)
+            except ValueError:
+                raise ValueError("Invalid JSON: %r" % x)
+            if not isinstance(x, dict):
+                raise ValueError("Not a place document: %r" % x)
+            return x
+
+        service_area = _load_area(parsed.service_area)
+        focus_area = _load_area(parsed.focus_area)
+
+        service_area, focus_area = AuthenticationDocument.parse_service_and_focus_area(
+            self._db, service_area, focus_area, place_class
+        )         
+        for (valid, unknown, ambiguous) in [service_area, focus_area]:
+            if unknown:
+                raise ValueError("Unknown places: %r" % unknown.items())
+            if ambiguous:
+                raise ValueError("Ambiguous places: %r" % unknown.items())
+
+        AuthenticationDocument.set_service_areas(
+            library, service_area, focus_area
+        )
 
 
 class AdobeVendorIDAcceptanceTestScript(Script):

--- a/tests/test_authentication_document.py
+++ b/tests/test_authentication_document.py
@@ -19,45 +19,10 @@ from model import (
 )
 from util.problem_detail import ProblemDetail
 from problem_details import INVALID_INTEGRATION_DOCUMENT
+from testing import MockPlace
 
 # Alias for a long class name
 AuthDoc = AuthenticationDocument
-
-class MockPlace(object):
-    """Used to test AuthenticationDocument.parse_coverage."""
-
-    # Used to indicate that a place name is ambiguous.
-    AMBIGUOUS = object()
-
-    # Used to indicate coverage through the universe or through a
-    # country.
-    EVERYWHERE = object()
-
-    by_name = dict()
-
-    def __init__(self, inside=None):
-        self.inside = inside or dict()
-
-    @classmethod
-    def lookup_one_by_name(cls, _db, name, place_type):
-        place = cls.by_name.get(name)
-        if place is cls.AMBIGUOUS:
-            raise MultipleResultsFound()
-        if place is None:
-            raise NoResultFound()
-        return place
-        
-    def lookup_inside(self, name):
-        place = self.inside.get(name)
-        if place is self.AMBIGUOUS:
-            raise MultipleResultsFound()
-        if place is None:
-            raise NoResultFound()
-        return place
-
-    @classmethod
-    def everywhere(cls, _db):
-        return cls.EVERYWHERE
 
 class TestParseCoverage(object):
 

--- a/tests/test_scripts.py
+++ b/tests/test_scripts.py
@@ -336,6 +336,7 @@ class TestSetCoverageAreaScript(DatabaseTest):
                 "Ambiguous places:",
                 s.run, args, place_class=MockPlace
             )
+        MockPlace.by_name = {}
 
     def test_success(self):
         us = self._place(type=Place.NATION, abbreviated_name='US')

--- a/tests/test_scripts.py
+++ b/tests/test_scripts.py
@@ -1,3 +1,4 @@
+import json
 from nose.tools import (
     assert_raises_regexp,
     set_trace,
@@ -20,8 +21,10 @@ from scripts import (
     LoadPlacesScript,
     SearchLibraryScript,
     SearchPlacesScript,
+    SetCoverageAreaScript,
     ShowIntegrationsScript,
 )
+from testing import MockPlace
 from . import (
     DatabaseTest
 )
@@ -278,4 +281,85 @@ class TestConfigureIntegrationScript(DatabaseTest):
         eq_(expect_output, output.getvalue())
        
 
+class TestSetCoverageAreaScript(DatabaseTest):
 
+    def test_argument_parsing(self):
+        library = self._library()
+        s = SetCoverageAreaScript(_db=self._db)
+        base = ["--library=%s" % library.name]
+        assert_raises_regexp(
+            Exception,
+            "Either --service-area or --focus-area must be specified",
+            s.run, base, place_class=MockPlace
+        )
+
+        for arg in ['service-area', 'focus-area']:
+            args = base + ['--%s=NotJSON' % arg]
+            print args
+            assert_raises_regexp(
+                ValueError,
+                "Invalid JSON:",
+                s.run, args, place_class=MockPlace
+            )
+
+            not_a_place = json.dumps("Not a place")
+            args = base + ['--%s=%s' % (arg, not_a_place)]
+            assert_raises_regexp(
+                ValueError,
+                "Not a place document:",
+                s.run, args, place_class=MockPlace
+            )
+
+    def test_unrecognized_place(self):      
+        library = self._library()
+        s = SetCoverageAreaScript(_db=self._db)
+        for arg in ['service-area', 'focus-area']:        
+            args = ["--library=%s" % library.name, 
+                    '--%s={"US": "San Francisco"}' % arg]
+            assert_raises_regexp(
+                ValueError,
+                "Unknown places:",
+                s.run, args, place_class=MockPlace
+            )
+
+    def test_ambiguous_place(self):
+
+        MockPlace.by_name["OO"] = MockPlace.AMBIGUOUS
+
+        library = self._library()
+        s = SetCoverageAreaScript(_db=self._db)
+        for arg in ['service-area', 'focus-area']:        
+            args = ["--library=%s" % library.name, 
+                    '--%s={"OO": "everywhere"}' % arg]
+            assert_raises_regexp(
+                ValueError,
+                "Ambiguous places:",
+                s.run, args, place_class=MockPlace
+            )
+
+    def test_success(self):
+        us = self._place(type=Place.NATION, abbreviated_name='US')
+        library = self._library()
+        s = SetCoverageAreaScript(_db=self._db)
+
+        # Setting a service area with no focus area assigns that
+        # service area to the library.
+        args = ["--library=%s" % library.name, 
+                '--service-area={"US": "everywhere"}']
+        s.run(args)
+        [area] = library.service_areas
+        eq_(us, area.place)
+
+        # Setting a focus area and not a service area treats 'everywhere'
+        # as the service area.
+        uk = self._place(type=Place.NATION, abbreviated_name='UK')
+        args = ["--library=%s" % library.name,
+                '--focus-area={"UK": "everywhere"}']
+        s.run(args)
+        places = [x.place for x in library.service_areas]
+        eq_(2, len(places))
+        assert uk in places
+        assert Place.everywhere(self._db) in places
+
+        # The library's former ServiceAreas have been removed.
+        assert us not in places


### PR DESCRIPTION
This branch introduces a script for setting a library's service area and focus area. We can use this script to set this information on a per-library basis until we develop a service area editor as part of the circulation manager admin interface.

I refactored a lot of the area-parsing code in `authentication_document.py` so I could call it outside the context of a full authentication document, and moved `MockPlace` into `testing.py` since it's now needed in multiple testing modules.