### PR TITLE
Serve terms of service as part of a document that describes the registration process

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,7 @@ git:
 
 before_install:
   - pip install "setuptools>=18.5"
-  - sudo apt-get install -y postgresql-9.3-postgis-2.3 postgis
+  - sudo apt-get install -y postgresql-9.3-postgis-2.3
   - sleep 10
 
 install:

--- a/app.py
+++ b/app.py
@@ -67,7 +67,7 @@ def nearby_qa():
         originating_ip(), live=False
     )
 
-@app.route("/register", methods=["GET,POST"])
+@app.route("/register", methods=["GET","POST"])
 @returns_problem_detail
 def register():
     return app.library_registry.registry_controller.register()

--- a/app.py
+++ b/app.py
@@ -4,7 +4,7 @@ import sys
 import urlparse
 
 from flask import Flask, url_for, redirect, Response, request
-from flask.ext.babel import Babel
+from flask_babel import Babel
 from flask_sqlalchemy_session import flask_scoped_session
 
 from config import Configuration

--- a/app.py
+++ b/app.py
@@ -67,7 +67,7 @@ def nearby_qa():
         originating_ip(), live=False
     )
 
-@app.route("/register", methods=["POST"])
+@app.route("/register", methods=["GET,POST"])
 @returns_problem_detail
 def register():
     return app.library_registry.registry_controller.register()

--- a/authentication_document.py
+++ b/authentication_document.py
@@ -1,7 +1,7 @@
 from collections import defaultdict
 import json
 from nose.tools import set_trace
-from flask.ext.babel import lazy_gettext as _
+from flask_babel import lazy_gettext as _
 from sqlalchemy.orm.exc import (
     MultipleResultsFound,
     NoResultFound,

--- a/config.py
+++ b/config.py
@@ -38,6 +38,8 @@ class Configuration(object):
     ADOBE_VENDOR_ID = "vendor_id"
     ADOBE_VENDOR_ID_NODE_VALUE = "node_value"
     ADOBE_VENDOR_ID_DELEGATE_URL = "delegate_url"
+
+    REGISTRATION_TERMS_OF_SERVICE_TEXT = "registration_terms_of_service_text"
     
     @classmethod
     def load(cls):

--- a/controller.py
+++ b/controller.py
@@ -1,7 +1,7 @@
 from nose.tools import set_trace
 import logging
 import flask
-from flask.ext.babel import lazy_gettext as _
+from flask_babel import lazy_gettext as _
 from flask import (
     Response,
     url_for,

--- a/controller.py
+++ b/controller.py
@@ -463,4 +463,4 @@ class LibraryRegistryController(object):
         else:
             status_code = 200
 
-        return self.catalog_response(content, status_code)
+        return self.catalog_response(catalog, status_code)

--- a/model.py
+++ b/model.py
@@ -1,6 +1,6 @@
 import base64
 from config import Configuration
-from flask.ext.babel import lazy_gettext as _
+from flask_babel import lazy_gettext as _
 import datetime
 import logging
 from nose.tools import set_trace

--- a/model.py
+++ b/model.py
@@ -1420,7 +1420,7 @@ class ExternalIntegration(Base):
         return self.setting(self.URL).value
 
     @url.setter
-    def set_url(self, new_url):
+    def url(self, new_url):
         self.set_setting(self.URL, new_url)
 
     @hybrid_property
@@ -1428,7 +1428,7 @@ class ExternalIntegration(Base):
         return self.setting(self.USERNAME).value
 
     @username.setter
-    def set_username(self, new_username):
+    def username(self, new_username):
         self.set_setting(self.USERNAME, new_username)
 
     @hybrid_property
@@ -1436,7 +1436,7 @@ class ExternalIntegration(Base):
         return self.setting(self.PASSWORD).value
 
     @password.setter
-    def set_password(self, new_password):
+    def password(self, new_password):
         return self.set_setting(self.PASSWORD, new_password)
 
     def set_setting(self, key, value):

--- a/model.py
+++ b/model.py
@@ -1628,7 +1628,7 @@ class ConfigurationSetting(Base):
         return self._value
     
     @value.setter
-    def set_value(self, new_value):
+    def value(self, new_value):
         self._value = new_value
 
     def setdefault(self, default=None):

--- a/problem_details.py
+++ b/problem_details.py
@@ -1,5 +1,5 @@
 from util.problem_detail import ProblemDetail as pd
-from flask.ext.babel import lazy_gettext as _
+from flask_babel import lazy_gettext as _
 
 NO_AUTH_URL = pd(
       "http://librarysimplified.org/terms/problem/no-opds-auth-url",

--- a/tests/test_controller.py
+++ b/tests/test_controller.py
@@ -324,7 +324,7 @@ class TestLibraryRegistryController(ControllerTest):
         with self.app.test_request_context("/", method="GET"):
             response = self.controller.register()
             eq_(200, response.status_code)
-            data = json.loads("response.data")
+            data = json.loads(response.data)
             [link] = data['links']
             eq_("terms-of-service", link["rel"])
             eq_("data:text/html;%s" % base64.encodestring(tos),
@@ -685,7 +685,7 @@ class TestLibraryRegistryController(ControllerTest):
 
         # So the library re-registers itself, and gets an updated
         # registry entry.
-        with self.app.test_request_context("/"):
+        with self.app.test_request_context("/", method="POST"):
             flask.request.form = ImmutableMultiDict([("url", auth_url)])
 
             response = self.controller.register(do_get=self.http_client.do_get)
@@ -727,7 +727,7 @@ class TestLibraryRegistryController(ControllerTest):
 
         # If we include the old secret in a request, the registry will
         # generate a new secret.
-        with self.app.test_request_context("/", headers={"Authorization": "Bearer %s" % old_secret}):
+        with self.app.test_request_context("/", headers={"Authorization": "Bearer %s" % old_secret}, method="POST"):
             flask.request.form = ImmutableMultiDict([
                 ("url", "http://circmanager.org/authentication.opds"),
             ])

--- a/util/app_server.py
+++ b/util/app_server.py
@@ -7,7 +7,7 @@ import sys
 from lxml import etree
 from functools import wraps
 from flask import make_response
-from flask.ext.babel import lazy_gettext as _
+from flask_babel import lazy_gettext as _
 from util.flask_util import problem
 from util.problem_detail import ProblemDetail
 import traceback

--- a/util/problem_detail.py
+++ b/util/problem_detail.py
@@ -4,7 +4,7 @@ As per http://datatracker.ietf.org/doc/draft-ietf-appsawg-http-problem/
 """
 import json as j
 import logging
-from flask.ext.babel import LazyString
+from flask_babel import LazyString
 
 JSON_MEDIA_TYPE = "application/api-problem+json"
 


### PR DESCRIPTION
This branch makes the registration endpoint for a library registry respond to GET as well as POST. A GET request will give an OPDS 2 catalog containing (at most) one link. This link is a `data:` link describing the terms of service for the registration endpoint. This is as opposed to the catalog endpoints, which  don't have any special terms of service, because their users are random library patrons who don't even know they're using a separate service. But in theory, there could be a different TOS for the registry as a whole.

The circulation manager will retrieve the registration TOS and require a would-be registrar to agree to it before proceeding.

Since this is the first library registry branch in nearly a year, I had to make a number of changes to make sure the code worked and the Travis tests ran with recent dependencies.