### PR TITLE
Reject registration requests that don't include the three required email addresses

### DIFF
--- a/controller.py
+++ b/controller.py
@@ -283,7 +283,7 @@ class LibraryRegistryController(object):
 
         integration_contact_uri = flask.request.form.get("contact")
         integration_contact_email = self._required_email_address(
-            integration_contact_uri, "Invalid integration contact address"
+            integration_contact_uri, "No valid integration contact address"
         )
         if isinstance(integration_contact_email, ProblemDetail):
             return integration_contact_email
@@ -364,7 +364,7 @@ class LibraryRegistryController(object):
         for l in auth_document.links:
             links_by_rel[l.get('rel')].append(l)
         for rel, problem_title in [
-                ('help', "No valid patron help URI"),
+                ('help', "No valid patron help email address"),
                 ("http://librarysimplified.org/rel/designated-agent/copyright",
                  "No valid copyright designated agent email address")
         ]:

--- a/problem_details.py
+++ b/problem_details.py
@@ -35,3 +35,8 @@ ERROR_RETRIEVING_DOCUMENT = pd(
     detail=_("I couldn't retrieve the specified URL."),
 )
 
+INVALID_CONTACT_URI = pd(
+    "http://librarysimplified.org/terms/problem/invalid-contact-uri",
+    400,
+    title=_("URI was not specified or is of the wrong type")
+)

--- a/tests/test_controller.py
+++ b/tests/test_controller.py
@@ -595,6 +595,38 @@ class TestLibraryRegistryController(ControllerTest):
 
             response = self.controller.register(do_get=self.http_client.do_get)
             eq_(201, response.status_code)
+
+    def test_register_fails_on_no_contact_email(self):
+        with self.app.test_request_context("/", method="POST"):
+            flask.request.form = ImmutableMultiDict([
+                ("url", "http://circmanager.org/authentication.opds"),
+            ])
+            response = self.controller.register(do_get=self.http_client.do_get)
+            eq_("No valid integration contact address", response.title)
+
+    def test_register_fails_on_no_copyright_agent_email(self):
+        auth_document = self._auth_document()
+        auth_document['links'] = filter(
+            lambda x: x['rel'] != "http://librarysimplified.org/rel/designated-agent/copyright",
+            auth_document['links']
+        )
+        self.http_client.queue_response(200, content=json.dumps(auth_document))
+        with self.app.test_request_context("/", method="POST"):
+            flask.request.form = self.registration_form
+            response = self.controller.register(do_get=self.http_client.do_get)
+            eq_("No valid copyright designated agent email address", response.title)
+
+    def test_register_fails_on_no_patron_help_email(self):
+        auth_document = self._auth_document()
+        auth_document['links'] = filter(
+            lambda x: x['rel'] != "help" or not x['href'].startswith("mailto:"),
+            auth_document['links']
+        )
+        self.http_client.queue_response(200, content=json.dumps(auth_document))
+        with self.app.test_request_context("/", method="POST"):
+            flask.request.form = self.registration_form
+            response = self.controller.register(do_get=self.http_client.do_get)
+            eq_("No valid patron help email address", response.title)
         
     def test_register_success(self):
         opds_directory = "application/opds+json;profile=https://librarysimplified.org/rel/profile/directory"


### PR DESCRIPTION
This branch addresses https://jira.nypl.org/browse/SIMPLY-467. Registrations will only succeed if a `contact` email address is provided along with the registration request, and the library's Authentication For OPDS includes an email address for patron support and an email address for the designated copyright agent.

Currently the email addresses are not stored anywhere and nothing is done with them -- they just have to be present at the time the library is registered.