### PR TITLE
Store incoming email addresses associated with a library

### DIFF
--- a/controller.py
+++ b/controller.py
@@ -1,4 +1,3 @@
-from collections import defaultdict
 from nose.tools import set_trace
 import logging
 import flask
@@ -24,6 +23,7 @@ from authentication_document import AuthenticationDocument
 from model import (
     production_session,
     ConfigurationSetting,
+    Hyperlink,
     Library,
     ServiceArea,
     get_one_or_create,
@@ -287,6 +287,9 @@ class LibraryRegistryController(object):
         )
         if isinstance(integration_contact_email, ProblemDetail):
             return integration_contact_email
+        hyperlinks_to_create = [
+            (Hyperlink.INTEGRATION_CONTACT_REL, [integration_contact_email])
+        ]
 
         def _make_request(url, on_404, on_timeout, on_exception, allow_401=False):
             allowed_codes = ["2xx", "3xx", 404]
@@ -359,23 +362,18 @@ class LibraryRegistryController(object):
             return INVALID_INTEGRATION_DOCUMENT.detailed(failure_detail)
 
         # Make sure the authentication document includes a way for
-        # patrons to get help or file a copyright complaint.
-        links_by_rel = defaultdict(list)
-        for l in auth_document.links:
-            links_by_rel[l.get('rel')].append(l)
+        # patrons to get help or file a copyright complaint. Store these
+        # links in the database as Hyperlink objects.
+        links = auth_document.links or []
         for rel, problem_title in [
-                ('help', "No valid patron help email address"),
-                ("http://librarysimplified.org/rel/designated-agent/copyright",
-                 "No valid copyright designated agent email address")
+            ('help', "No valid patron help email address"),
+            (Hyperlink.COPYRIGHT_DESIGNATED_AGENT_REL,
+             "No valid copyright designated agent email address")
         ]:
-            links = links_by_rel.get(rel, [])
-            if not links:
-                problem = INVALID_CONTACT_URI.detailed("")
-                problem.title = problem_title
-                return problem
-            address = self._locate_email_address(links, problem_title)
-            if isinstance(address, ProblemDetail):
-                return address
+            uris = self._locate_email_addresses(rel, links, problem_title)
+            if isinstance(uris, ProblemDetail):
+                return uris
+            hyperlinks_to_create.append((rel, uris))
 
         # Cross-check the opds_url to make sure it links back to the
         # authentication document.
@@ -485,6 +483,10 @@ class LibraryRegistryController(object):
 
             catalog["metadata"]["short_name"] = library.short_name
             catalog["metadata"]["shared_secret"] = base64.b64encode(encrypted_secret)
+
+        for rel, candidates in hyperlinks_to_create:
+            library.set_hyperlink(rel, *candidates)
+
         if is_new:
             status_code = 201
         else:
@@ -512,20 +514,33 @@ class LibraryRegistryController(object):
         return uri
 
     @classmethod
-    def _locate_email_address(cls, links, problem_title):
-        """Find an email address in a list of links.
+    def _locate_email_addresses(cls, rel, links, problem_title):
+        """Find one or more email addresses in a list of links, all with
+        a given `rel`.
 
-        :return: Either an email address or a customized ProblemDetail.
+        :param library: A Library
+        :param rel: The rel for this type of link.
+        :param links: A list of dictionaries with keys 'rel' and 'href'
+        :problem_title: The title to use in a ProblemDetail if no
+            valid links are found.
+        :return: Either a list of candidate links or a customized ProblemDetail.
         """
-        value = None
+        candidates = []
         for link in links:
+            if link.get('rel') != rel:
+                # Wrong kind of link.
+                continue
             uri = link.get('href')
             value = cls._required_email_address(uri, problem_title)
             if isinstance(value, basestring):
-                # We found an email address.
-                return value
+                candidates.append(value)
 
         # There were no relevant links.
-        value = INVALID_CONTACT_URI.detailed("No valid mailto: links found.")
-        value.title = problem_title
-        return value
+        if not candidates:
+            problem = INVALID_CONTACT_URI.detailed(
+                "No valid mailto: links found with rel=%s" % rel
+            )
+            problem.title = problem_title
+            return problem
+
+        return candidates

--- a/controller.py
+++ b/controller.py
@@ -369,7 +369,7 @@ class LibraryRegistryController(object):
         for rel, problem_title in [
             ('help', "Invalid or missing patron support email address"),
             (Hyperlink.COPYRIGHT_DESIGNATED_AGENT_REL,
-             "Invalid or missing copyright designated agent email")
+             "Invalid or missing copyright designated agent email address")
         ]:
             uris = self._locate_email_addresses(rel, links, problem_title)
             if isinstance(uris, ProblemDetail):

--- a/controller.py
+++ b/controller.py
@@ -283,7 +283,8 @@ class LibraryRegistryController(object):
 
         integration_contact_uri = flask.request.form.get("contact")
         integration_contact_email = self._required_email_address(
-            integration_contact_uri, "No valid integration contact address"
+            integration_contact_uri,
+            "Invalid or missing configuration contact email address"
         )
         if isinstance(integration_contact_email, ProblemDetail):
             return integration_contact_email
@@ -366,9 +367,9 @@ class LibraryRegistryController(object):
         # links in the database as Hyperlink objects.
         links = auth_document.links or []
         for rel, problem_title in [
-            ('help', "No valid patron help email address"),
+            ('help', "Invalid or missing patron support email address"),
             (Hyperlink.COPYRIGHT_DESIGNATED_AGENT_REL,
-             "No valid copyright designated agent email address")
+             "Invalid or missing copyright designated agent email")
         ]:
             uris = self._locate_email_addresses(rel, links, problem_title)
             if isinstance(uris, ProblemDetail):

--- a/model.py
+++ b/model.py
@@ -786,8 +786,10 @@ class Library(Base):
             is True if a new Hyperlink was created _or_ an existing
             Hyperlink was modified.
         """
+        if not rel:
+            raise ValueError("No link relation was specified")
         if not hrefs:
-            raise ValueError("No Hyperlink href was specified")
+            raise ValueError("No Hyperlink hrefs were specified")
         default_href = hrefs[0]
         _db = Session.object_session(self)
         hyperlink, is_modified = get_one_or_create(

--- a/model.py
+++ b/model.py
@@ -1206,12 +1206,10 @@ class Hyperlink(Base):
     INTEGRATION_CONTACT_REL = "http://librarysimplified.org/rel/integration-contact"
     COPYRIGHT_DESIGNATED_AGENT_REL = "http://librarysimplified.org/rel/designated-agent/copyright"
 
-    __tablename__ = 'hyperlinks',
+    __tablename__ = 'hyperlinks'
 
     id = Column(Integer, primary_key=True)
-    library_id = Column(
-        Integer, ForeignKey('libraries.id'), index=True
-    )
+    library_id = Column(Integer, ForeignKey('libraries.id'), index=True)
     rel = Column(Unicode, index=True, nullable=False)
     href = Column(Unicode, nullable=False)
 

--- a/model.py
+++ b/model.py
@@ -257,7 +257,7 @@ class Library(Base):
     # Can eligible people get credentials for this library through
     # an online registration process?
     online_registration = Column(Boolean, default=False)
-    
+
     # To issue Short Client Tokens for this library, the registry must share a
     # short name and a secret with them.
 
@@ -274,6 +274,8 @@ class Library(Base):
     delegated_patron_identifiers = relationship(
         "DelegatedPatronIdentifier", backref='library'
     )
+
+    hyperlinks = relationship("Hyperlink", backref='library')
     
     __table_args__ = (
         UniqueConstraint('urn'),
@@ -771,6 +773,38 @@ class Library(Base):
         else:
             return 'urn:' + self.urn
     
+    def set_hyperlink(self, rel, *hrefs):
+        """Make sure this library has a Hyperlink with the given `rel` that
+        points to one of the given `href`s.
+
+        If there's already a matching Hyperlink, it will be returned
+        unmodified. Otherwise, the first item in `hrefs` will be used
+        as the basis for a new Hyperlink, or an existing Hyperlink
+        will be modified to use the first item in `hrefs`.
+
+        :return: A 2-tuple (Hyperlink, is_modified). `is_modified`
+            is True if a new Hyperlink was created _or_ an existing
+            Hyperlink was modified.
+        """
+        if not hrefs:
+            raise ValueError("No Hyperlink href was specified")
+        default_href = hrefs[0]
+        _db = Session.object_session(self)
+        hyperlink, is_modified = get_one_or_create(
+            _db, Hyperlink, library=self, rel=rel,
+            create_method_kwargs=dict(href=default_href)
+        )
+        if hyperlink.href not in hrefs:
+            # This is a preexisting Hyperlink whose href doesn't
+            # match any of the given hrefs.
+            hyperlink.href = default_href
+            is_modified = True
+
+        # TODO: If a Hyperlink is modified, it loses any verification
+        # status it had.
+        return hyperlink, is_modified
+
+
 class LibraryAlias(Base):
 
     """An alternate name for a library."""
@@ -1159,6 +1193,33 @@ class CollectionSummary(Base):
         return summary
     
 Index("ix_collectionsummary_language_size", CollectionSummary.language, CollectionSummary.size)
+
+
+class Hyperlink(Base):
+    """A URI associated with a Library.
+
+    We trust that this URI is actually associated with the Library
+    because the library told us about it; either directly, during
+    registration, or by putting a link in its Authentication For OPDS
+    document.
+    """
+    INTEGRATION_CONTACT_REL = "http://librarysimplified.org/rel/integration-contact"
+    COPYRIGHT_DESIGNATED_AGENT_REL = "http://librarysimplified.org/rel/designated-agent/copyright"
+
+    __tablename__ = 'hyperlinks',
+
+    id = Column(Integer, primary_key=True)
+    library_id = Column(
+        Integer, ForeignKey('libraries.id'), index=True
+    )
+    rel = Column(Unicode, index=True, nullable=False)
+    href = Column(Unicode, nullable=False)
+
+    # A Library can have multiple links with the same rel, but we only
+    # need to keep track of one.
+    __table_args__ = (
+        UniqueConstraint('library_id', 'rel'),
+    )
 
 
 class DelegatedPatronIdentifier(Base):

--- a/tests/test_controller.py
+++ b/tests/test_controller.py
@@ -28,6 +28,7 @@ from model import (
     get_one_or_create,
     ConfigurationSetting,
     ExternalIntegration,
+    Hyperlink,
     Library,
 )
 from util.http import RequestTimedOut
@@ -714,6 +715,18 @@ class TestLibraryRegistryController(ControllerTest):
         old_secret = library.shared_secret
         self.http_client.requests = []
 
+        # Hyperlink objects were created for the three email addresses
+        # associated with the library.
+        help_link, copyright_agent_link, integration_contact_link = sorted(
+            library.hyperlinks, key=lambda x: x.rel
+        )
+        eq_("help", help_link.rel)
+        eq_("mailto:help@library.org", help_link.href)
+        eq_(Hyperlink.COPYRIGHT_DESIGNATED_AGENT_REL, copyright_agent_link.rel)
+        eq_("mailto:dmca@library.org", copyright_agent_link.href)
+        eq_(Hyperlink.INTEGRATION_CONTACT_REL, integration_contact_link.rel)
+        eq_("mailto:me@library.org", integration_contact_link.href)
+
         # A human inspects the library, verifies that everything
         # works, and makes it LIVE.
         library.stage = Library.LIVE
@@ -738,7 +751,6 @@ class TestLibraryRegistryController(ControllerTest):
         # We have a new logo as well.
         image_data = '\x89PNG\r\n\x1a\n\x00\x00\x00\rIHDR\x00\x00\x00\x01\x00\x00\x00\x01\x01\x03\x00\x00\x00%\xdbV\xca\x00\x00\x00\x06PLTE\xffM\x00\x01\x01\x01\x8e\x1e\xe5\x1b\x00\x00\x00\x01tRNS\xcc\xd24V\xfd\x00\x00\x00\nIDATx\x9cc`\x00\x00\x00\x02\x00\x01H\xaf\xa4q\x00\x00\x00\x00IEND\xaeB`\x82'
         self.http_client.queue_response(200, content=image_data, media_type="image/png")
-
 
         # So the library re-registers itself, and gets an updated
         # registry entry.
@@ -768,6 +780,21 @@ class TestLibraryRegistryController(ControllerTest):
             # The library's stage is still LIVE, it has not gone back to
             # REGISTERED.
             eq_(Library.LIVE, library.stage)
+
+            # There are still three Hyperlinks associated with the
+            # library. Two of them have changed their hrefs to reflect
+            # what's in the new authentication document
+            help_link, copyright_agent_link, integration_contact_link = sorted(
+                library.hyperlinks, key=lambda x: x.rel
+            )
+            eq_("help", help_link.rel)
+            eq_("mailto:new-help@library.org", help_link.href)
+            eq_(Hyperlink.COPYRIGHT_DESIGNATED_AGENT_REL, copyright_agent_link.rel)
+            eq_("mailto:new-dmca@library.org", copyright_agent_link.href)
+
+            # The link that hasn't changed is unaffected.
+            eq_(Hyperlink.INTEGRATION_CONTACT_REL, integration_contact_link.rel)
+            eq_("mailto:me@library.org", integration_contact_link.href)
             
             # Commit to update library.service_areas.
             self._db.commit()
@@ -1002,27 +1029,30 @@ class TestLibraryRegistryController(ControllerTest):
         success = m(mailto, "a title")
         eq_(mailto, success)
 
-    def test__locate_email_address(self):
+    def test__locate_email_addresses(self):
         """Test the code that finds an email address in a list of links."""
         uri = INVALID_CONTACT_URI.uri
-        m = LibraryRegistryController._locate_email_address
+        m = LibraryRegistryController._locate_email_addresses
 
         # No links at all.
-        result = m([], "a title")
+        result = m("rel0", [], "a title")
         assert isinstance(result, ProblemDetail)
         eq_(uri, result.uri)
         eq_("a title", result.title)
-        eq_("No valid mailto: links found.", result.detail)
+        eq_("No valid mailto: links found with rel=rel0", result.detail)
 
-        # Links, but they're all bad.
-        links = [dict(href="http://foo/"), dict(href="http://bar/")]
-        result = m(links, "a title")
+        # Links exist but none are valid and relevant.
+        links = [dict(rel="rel1", href="http://foo/"),
+                 dict(rel="rel1", href="http://bar/"),
+                 dict(rel="rel2", href="mailto:me@library.org"),
+                 dict(rel="rel2", href="mailto:me2@library.org"),
+        ]
+        result = m("rel1", links, "a title")
         assert isinstance(result, ProblemDetail)
         eq_(uri, result.uri)
         eq_("a title", result.title)
-        eq_("No valid mailto: links found.", result.detail)
+        eq_("No valid mailto: links found with rel=rel1", result.detail)
 
-        # One link that works.
-        links.append(dict(href="mailto:me@library.org"))
-        result = m(links, "a title")
-        eq_("mailto:me@library.org", result)
+        # Multiple links that work.
+        result = m("rel2", links, "a title")
+        eq_(["mailto:me@library.org", "mailto:me2@library.org"], result)

--- a/tests/test_controller.py
+++ b/tests/test_controller.py
@@ -782,11 +782,18 @@ class TestLibraryRegistryController(ControllerTest):
             eq_(Library.LIVE, library.stage)
 
             # There are still three Hyperlinks associated with the
-            # library. Two of them have changed their hrefs to reflect
-            # what's in the new authentication document
-            help_link, copyright_agent_link, integration_contact_link = sorted(
+            # library.
+            help_link_2, copyright_agent_link_2, integration_contact_link_2 = sorted(
                 library.hyperlinks, key=lambda x: x.rel
             )
+
+            # The Hyperlink objects are the same as before.
+            eq_(help_link_2, help_link)
+            eq_(copyright_agent_link_2, copyright_agent_link)
+            eq_(integration_contact_link_2, integration_contact_link)
+
+            # But two of the hrefs have been updated to reflect the new
+            # authentication document.
             eq_("help", help_link.rel)
             eq_("mailto:new-help@library.org", help_link.href)
             eq_(Hyperlink.COPYRIGHT_DESIGNATED_AGENT_REL, copyright_agent_link.rel)

--- a/tests/test_controller.py
+++ b/tests/test_controller.py
@@ -603,21 +603,23 @@ class TestLibraryRegistryController(ControllerTest):
                 ("url", "http://circmanager.org/authentication.opds"),
             ])
             response = self.controller.register(do_get=self.http_client.do_get)
-            eq_("No valid integration contact address", response.title)
+            eq_("Invalid or missing configuration contact email address",
+                response.title)
 
             flask.request.form = ImmutableMultiDict([
                 ("url", "http://circmanager.org/authentication.opds"),
                 ("contact", "http://contact-us/")
             ])
             response = self.controller.register(do_get=self.http_client.do_get)
-            eq_("No valid integration contact address", response.title)
+            eq_("Invalid or missing configuration contact email address",
+                response.title)
 
     def test_register_fails_on_missing_email_in_authentication_document(self):
 
         for (rel, error) in (
                 ("http://librarysimplified.org/rel/designated-agent/copyright",
-                 "No valid copyright designated agent email address"),
-                ("help", "No valid patron help email address")
+                 "Invalid or missing copyright designated agent email address"),
+                ("help", "Invalid or missing patron support email address")
         ):
             # Start with a valid document.
             auth_document = self._auth_document()

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -274,7 +274,45 @@ class TestLibrary(DatabaseTest):
         except ValueError, e:
             eq_('Short name cannot contain the pipe character.',
                 e.message)
-        
+
+    def test_set_hyperlink(self):
+        library = self._library()
+
+        assert_raises_regexp(
+            ValueError, "No Hyperlink hrefs were specified",
+            library.set_hyperlink, "rel"
+        )
+
+        assert_raises_regexp(
+            ValueError, "No link relation was specified",
+            library.set_hyperlink, None, ["href"]
+        )
+
+        link, is_modified = library.set_hyperlink("rel", "href1", "href2")
+        eq_("rel", link.rel)
+        eq_("href1", link.href)
+        eq_(True, is_modified)
+
+        # Calling set_hyperlink again does not modify the link
+        # so long as the old href is still a possibility.
+        link2, is_modified = library.set_hyperlink("rel", "href2", "href1")
+        eq_(link2, link)
+        eq_("rel", link2.rel)
+        eq_("href1", link2.href)
+        eq_(False, is_modified)
+
+        # If there is no way to keep a Hyperlink's href intact,
+        # set_hyperlink will modify it.
+        link3, is_modified = library.set_hyperlink("rel", "href2", "href3")
+        eq_(link3, link)
+        eq_("rel", link3.rel)
+        eq_("href2", link3.href)
+        eq_(True, is_modified)
+
+        # Under no circumstances will two hyperlinks for the same rel be
+        # created for a given library.
+        eq_([link3], library.hyperlinks)
+
     def test_library_service_area(self):
         zip = self.zip_10018
         nypl = self._library("New York Public Library", eligibility_areas=[zip])


### PR DESCRIPTION
This branch grabs the email addresses that come in associated with a library (the patron support address, the copyright designated agent address, and the configuration contact address) and stores them in a new table called Hyperlink. This is a lot simpler than the Hyperlink table in server_core but it's the same idea -- it's a URL (href) that has a specific relationship (rel) to a library.

Although a library may have multiple links of a given type, we only store one Hyperlink of a given type for a given library. The library's links may change over time, but we try to keep using the same value as long as that is a possibility.