### PR TITLE
Send out validation emails on registration

### DIFF
--- a/app.py
+++ b/app.py
@@ -86,9 +86,9 @@ def search_qa():
         originating_ip(), live=False
     )
 
-@app.route('/validate/<int:resource_id>/<secret>')
+@app.route('/confirm/<int:resource_id>/<secret>')
 @returns_problem_detail
-def validate_resource(secret):
+def confirm_resource(secret):
     return app.library_registry.validation_controller.validate(
         resource_id, secret
     )

--- a/controller.py
+++ b/controller.py
@@ -548,7 +548,7 @@ class LibraryRegistryController(object):
 class ValidationController(object):
     """Validates Resources based on validation codes.
 
-    The validation codes were sent out in emails to the addresses that
+    The confirmation codes were sent out in emails to the addresses that
     need to be validated, or otherwise communicated to someone who needs
     to click on the link to this controller.
     """
@@ -569,13 +569,13 @@ class ValidationController(object):
         page = self.MESSAGE_TEMPLATE % dict(message=message)
         return Response(page, status_code, headers=headers)
 
-    def validate(self, resource_id, secret):
-        """Validate a secret for a URI, or don't.
+    def confirm(self, resource_id, secret):
+        """Confirm a secret for a URI, or don't.
 
         :return: A Response containing a simple HTML document.
         """
         if not secret:
-            return self.html_response(404, _("No validation code provided"))
+            return self.html_response(404, _("No confirmation code provided"))
         if not resource_id:
             return self.html_response(404, _("No resource ID provided"))
         validation = get_one(self._db, Validation, secret=secret)
@@ -599,17 +599,17 @@ class ValidationController(object):
             # For whatever reason the resource ID and secret don't match.
             # A generic error that doesn't reveal information is appropriate
             # in all cases.
-            error = _("Validation code %r not found") % secret
+            error = _("Confirmation code %r not found") % secret
             return self.html_response(404, error)
 
         # At this point we know that the resource has not been
-        # validated, and that the secret matches the resource. The
+        # confirmed, and that the secret matches the resource. The
         # only other problem might be that the validation has expired.
         if not validation.active:
-            error = _("Validation code %r has expired. Re-register to get another code.") % secret
+            error = _("Confirmation code %r has expired. Re-register to get another code.") % secret
             return self.html_response(400, error)
         validation.mark_as_successful()
 
         resource = validation.resource
-        message = _("You successfully validated %s.") % resource.href
+        message = _("You successfully confirmed %s.") % resource.href
         return self.html_response(200, message)

--- a/emailer.py
+++ b/emailer.py
@@ -19,7 +19,7 @@ class Emailer(object):
 
     # Constants for different types of email.
     ADDRESS_DESIGNATED = 'address_designated'
-    ADDRESS_NEEDS_CONFIRMATION = 'address_registered'
+    ADDRESS_NEEDS_CONFIRMATION = 'address_needs_confirmation'
 
     EMAIL_TYPES = [ADDRESS_DESIGNATED, ADDRESS_NEEDS_CONFIRMATION]
 

--- a/model.py
+++ b/model.py
@@ -1259,6 +1259,9 @@ class Hyperlink(Base):
         :param url_for: An implementation of Flask's url_for, used to
             generate a validation link if necessary.
         """
+        if not emailer or not url_for:
+            # We can't actually send any emails.
+            return
         _db = Session.object_session(self)
 
         # These shouldn't happen, but just to be safe, do nothing if
@@ -1300,7 +1303,7 @@ class Hyperlink(Base):
         )
         if email_type == Emailer.ADDRESS_NEEDS_CONFIRMATION:
             template_args['confirmation_link'] = url_for(
-                "validate", resource_id=resource.id, secret=validation.secret
+                "confirm_resource", resource_id=resource.id, secret=validation.secret
             )
         body = emailer.send(email_type, to_address, **template_args)
         return body

--- a/tests/test_controller.py
+++ b/tests/test_controller.py
@@ -1105,7 +1105,7 @@ class TestValidationController(ControllerTest):
             and verify that html_response is called with the given
             status_code and message.
             """
-            result = controller.validate(resource_id, secret)
+            result = controller.confirm(resource_id, secret)
             eq_((status_code, message), result)
 
         # This library has three links: two that are in the middle of
@@ -1128,7 +1128,7 @@ class TestValidationController(ControllerTest):
 
         # Simple tests for missing fields or failed lookups.
         assert_response(
-            needs_validation.id, "", 404, "No validation code provided"
+            needs_validation.id, "", 404, "No confirmation code provided"
         )
         assert_response(None, "a code", 404, "No resource ID provided")
         assert_response(-20, secret, 404, "No such resource")
@@ -1136,18 +1136,18 @@ class TestValidationController(ControllerTest):
         # Secret does not exist.
         assert_response(
             needs_validation.id, "nosuchcode", 404,
-            "Validation code 'nosuchcode' not found"
+            "Confirmation code 'nosuchcode' not found"
         )
 
         # Secret exists but is associated with a different Resource.
         assert_response(needs_validation.id, secret2, 404,
-                        "Validation code %r not found" % secret2)
+                        "Confirmation code %r not found" % secret2)
 
         # Secret exists but is not associated with any Resource (this
         # shouldn't happen).
         needs_validation_2.validation.resource = None
         assert_response(needs_validation.id, secret2, 404,
-                        "Validation code %r not found" % secret2)
+                        "Confirmation code %r not found" % secret2)
 
         # Secret matches resource but validation has expired.
         needs_validation.validation.started_at = (
@@ -1155,7 +1155,7 @@ class TestValidationController(ControllerTest):
         )
         assert_response(
             needs_validation.id, secret, 400,
-            "Validation code %r has expired. Re-register to get another code." % secret
+            "Confirmation code %r has expired. Re-register to get another code." % secret
         )
 
         # Success.
@@ -1163,7 +1163,7 @@ class TestValidationController(ControllerTest):
         secret = needs_validation.validation.secret
         assert_response(
             needs_validation.id, secret, 200,
-            "You successfully validated mailto:1@library.org."
+            "You successfully confirmed mailto:1@library.org."
         )
 
         # A Resource can't be validated twice.

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -1253,7 +1253,7 @@ class TestHyperlink(DatabaseTest):
 
         # url_for was called to create the confirmation link.
         controller, kwargs = emailer.url_for_calls.pop()
-        eq_("validate", controller)
+        eq_("confirm_resource", controller)
         eq_(secret, kwargs['secret'])
         eq_(link.resource.id, kwargs['resource_id'])
 


### PR DESCRIPTION
This completes https://jira.nypl.org/browse/SIMPLY-1007. Confirmation and notification emails will now be sent out appropriately from a properly configured library registry.