### PR TITLE
Explain verification status of registered email addresses in a library's OPDS catalog

### DIFF
--- a/controller.py
+++ b/controller.py
@@ -502,6 +502,9 @@ class LibraryRegistryController(object):
             encryptor = PKCS1_OAEP.new(public_key)
 
             if not library.short_name:
+                # TODO: This needs to be base64 encoded or something,
+                # not hex encoded. Hex encoding limits us to 256*3
+                # libraries. Also we need to handle collisions.
                 library.short_name = os.urandom(3).encode('hex')
 
             submitted_secret = None

--- a/controller.py
+++ b/controller.py
@@ -488,12 +488,14 @@ class LibraryRegistryController(object):
                 # them a new library is using their address.
                 hyperlink.notify(self.emailer, self.app.url_for)
                     
-        # Create an OPDS 2 catalog containing all publicly available
+        # Create an OPDS 2 catalog containing all available
         # information about the library.
-        catalog = OPDSCatalog.library_catalog(library)
+        catalog = OPDSCatalog.library_catalog(
+            library, include_private_information=True
+        )
 
-        # Annotate the catalog with information that is _not_ publicly
-        # available.
+        # Annotate the catalog with some information specific to
+        # the transaction that's happening right now.
         public_key = auth_document.public_key
         if public_key and public_key.get("type") == "RSA":
             public_key = RSA.importKey(public_key.get("value"))

--- a/controller.py
+++ b/controller.py
@@ -57,7 +57,7 @@ OPDS_CATALOG_REGISTRATION_MEDIA_TYPE = "application/opds+json;profile=https://li
 
 class LibraryRegistry(object):
 
-    def __init__(self, _db=None, testing=False, emailer_class=None):
+    def __init__(self, _db=None, testing=False, emailer_class=Emailer):
 
         self.log = logging.getLogger("Library registry web app")
 
@@ -69,7 +69,7 @@ class LibraryRegistry(object):
 
         self.setup_controllers(emailer_class)
 
-    def setup_controllers(self, emailer_class=None):
+    def setup_controllers(self, emailer_class=Emailer):
         """Set up all the controllers that will be used by the web app."""
         self.registry_controller = LibraryRegistryController(
             self, emailer_class
@@ -290,15 +290,24 @@ class LibraryRegistryController(object):
             return NO_AUTH_URL
 
         integration_contact_uri = flask.request.form.get("contact")
-        integration_contact_email = self._required_email_address(
-            integration_contact_uri,
-            "Invalid or missing configuration contact email address"
-        )
+        integration_contact_email = integration_contact_uri
+
+        # NOTE: This is commented out until we can say that
+        # registration requires providing a contact email and expect
+        # every new library to be on a circulation manager that can meet
+        # this requirement.
+        #
+        #integration_contact_email = self._required_email_address(
+        #    integration_contact_uri,
+        #    "Invalid or missing configuration contact email address"
+        #)
         if isinstance(integration_contact_email, ProblemDetail):
             return integration_contact_email
-        hyperlinks_to_create = [
-            (Hyperlink.INTEGRATION_CONTACT_REL, [integration_contact_email])
-        ]
+        hyperlinks_to_create = []
+        if integration_contact_email:
+            hyperlinks_to_create.append(
+                (Hyperlink.INTEGRATION_CONTACT_REL, [integration_contact_email])
+            )
 
         def _make_request(url, on_404, on_timeout, on_exception, allow_401=False):
             allowed_codes = ["2xx", "3xx", 404]
@@ -469,16 +478,28 @@ class LibraryRegistryController(object):
                 auth_url, problem
             )
             return problem
+
+        for rel, candidates in hyperlinks_to_create:
+            hyperlink, is_modified = library.set_hyperlink(rel, *candidates)
+            if is_modified:
+                # We need to send an email to this email address about
+                # what just happened. This is either so the receipient
+                # can confirm that the address works, or to inform
+                # them a new library is using their address.
+                hyperlink.notify(self.emailer, self.app.url_for)
                     
+        # Create an OPDS 2 catalog containing all publicly available
+        # information about the library.
         catalog = OPDSCatalog.library_catalog(library)
 
+        # Annotate the catalog with information that is _not_ publicly
+        # available.
         public_key = auth_document.public_key
         if public_key and public_key.get("type") == "RSA":
             public_key = RSA.importKey(public_key.get("value"))
             encryptor = PKCS1_OAEP.new(public_key)
 
             if not library.short_name:
-                # TODO: Generate a short name based on the library's service area.
                 library.short_name = os.urandom(3).encode('hex')
 
             submitted_secret = None
@@ -493,15 +514,6 @@ class LibraryRegistryController(object):
 
             catalog["metadata"]["short_name"] = library.short_name
             catalog["metadata"]["shared_secret"] = base64.b64encode(encrypted_secret)
-
-        for rel, candidates in hyperlinks_to_create:
-            hyperlink, is_modified = library.set_hyperlink(rel, *candidates)
-            if is_modified:
-                # We need to send an email to this email address about
-                # what just happened. This is either so the receipient
-                # can confirm that the address works, or to inform
-                # them a new library is using their address.
-                hyperlink.notify(self.emailer, self.app.url_for)
 
         if is_new:
             status_code = 201

--- a/model.py
+++ b/model.py
@@ -1211,12 +1211,13 @@ class Hyperlink(Base):
     """
     INTEGRATION_CONTACT_REL = "http://librarysimplified.org/rel/integration-contact"
     COPYRIGHT_DESIGNATED_AGENT_REL = "http://librarysimplified.org/rel/designated-agent/copyright"
+    HELP_REL = "help"
 
     # Descriptions of the link relations, used in emails.
     REL_DESCRIPTIONS = {
         INTEGRATION_CONTACT_REL: "integration point of contact",
         COPYRIGHT_DESIGNATED_AGENT_REL: "copyright designated agent",
-        "help": "patron help contact address",
+        HELP_REL: "patron help contact address",
     }
 
     # Hyperlinks with these relations are not for public consumption.
@@ -1353,11 +1354,14 @@ class Validation(Base):
     started_at = Column(DateTime, index=True, nullable=False,
                         default = lambda x: datetime.datetime.utcnow())
 
+    # Used in OPDS catalogs to convey the status of a validation attempt.
+    STATUS_PROPERTY = "https://schema.org/reservationStatus"
+
     # These constants are used in OPDS catalogs as values of
     # schema:reservationStatus.
     CONFIRMED = "https://schema.org/ReservationConfirmed"
     IN_PROGRESS = "https://schema.org/ReservationPending"
-    UNCONFIRMED = "https://schema.org/ReservationCancelled"
+    INACTIVE = "https://schema.org/ReservationCancelled"
 
     # The only way to validate a Resource is to prove you know the
     # corresponding secret.

--- a/model.py
+++ b/model.py
@@ -1219,6 +1219,9 @@ class Hyperlink(Base):
         "help": "patron help contact address",
     }
 
+    # Hyperlinks with these relations are not for public consumption.
+    PRIVATE_RELS = [INTEGRATION_CONTACT_REL]
+
     __tablename__ = 'hyperlinks'
 
     id = Column(Integer, primary_key=True)
@@ -1349,6 +1352,12 @@ class Validation(Base):
     success = Column(Boolean, index=True, default=False)
     started_at = Column(DateTime, index=True, nullable=False,
                         default = lambda x: datetime.datetime.utcnow())
+
+    # These constants are used in OPDS catalogs as values of
+    # schema:reservationStatus.
+    CONFIRMED = "https://schema.org/ReservationConfirmed"
+    IN_PROGRESS = "https://schema.org/ReservationPending"
+    UNCONFIRMED = "https://schema.org/ReservationCancelled"
 
     # The only way to validate a Resource is to prove you know the
     # corresponding secret.

--- a/opds.py
+++ b/opds.py
@@ -1,6 +1,11 @@
 from nose.tools import set_trace
 import json
 
+from model import (
+    Hyperlink,
+    Validation,
+)
+
 class Annotator(object):
 
     def annotate_feed(self, feed):
@@ -61,7 +66,17 @@ class OPDSCatalog(object):
         annotator.annotate_catalog(self, live=live)
 
     @classmethod
-    def library_catalog(cls, library, distance=None):
+    def library_catalog(cls, library, distance=None,
+                        include_private_information=False):
+
+        """Create an OPDS catalog for a library.
+
+        :param include_private_information: If this is True, the
+        consumer of this OPDS catalog is expected to be the library
+        whose catalog it is. Private information such as the point of
+        contact for integration problems will be included, where it
+        normally wouldn't be.
+        """
         metadata = dict(
             id=library.urn_uri,
             title=library.name,
@@ -90,7 +105,47 @@ class OPDSCatalog(object):
                                      href=library.logo,
                                      type="image/png")
 
+        for hyperlink in library.hyperlinks:
+            if (not include_private_information and hyperlink.rel in
+                Hyperlink.PRIVATE_RELS):
+                continue
+            args = cls._hyperlink_args(hyperlink)
+            if not args:
+                # Not enough information to create a link.
+                continue
+            cls.add_link_to_catalog(
+                catalog, **args
+            )
         return catalog
+
+    @classmethod
+    def _hyperlink_args(cls, hyperlink):
+        """Turn a Hyperlink into a dictionary of arguments that can
+        be turned into an OPDS 2 link.
+        """
+        resource = hyperlink.resource
+        if not resource:
+            return None
+        href = resource.href
+        if not href:
+            return None
+        args = dict(rel=hyperlink.rel, href=href)
+
+        # If there was ever an attempt to validate this Hyperlink,
+        # explain the status of that attempt.
+        properties = {}
+        validation = resource.validation
+        if validation:
+            if validation.success:
+                status = Validation.CONFIRMED
+            elif validation.active:
+                status = Validation.IN_PROGRESS
+            else:
+                status = Validation.UNCONFIRMED
+            properties["https://schema.org/reservationStatus"] = status
+        if properties:
+            args['properties'] = properties
+        return args
 
     def __unicode__(self):
         if self.catalog is None:

--- a/opds.py
+++ b/opds.py
@@ -123,6 +123,8 @@ class OPDSCatalog(object):
         """Turn a Hyperlink into a dictionary of arguments that can
         be turned into an OPDS 2 link.
         """
+        if not hyperlink:
+            return None
         resource = hyperlink.resource
         if not resource:
             return None
@@ -141,8 +143,8 @@ class OPDSCatalog(object):
             elif validation.active:
                 status = Validation.IN_PROGRESS
             else:
-                status = Validation.UNCONFIRMED
-            properties["https://schema.org/reservationStatus"] = status
+                status = Validation.INACTIVE
+            properties[Validation.STATUS_PROPERTY] = status
         if properties:
             args['properties'] = properties
         return args

--- a/tests/test_controller.py
+++ b/tests/test_controller.py
@@ -33,6 +33,7 @@ from model import (
     ExternalIntegration,
     Hyperlink,
     Library,
+    Validation,
 )
 from util.http import RequestTimedOut
 from problem_details import *
@@ -782,7 +783,17 @@ class TestLibraryRegistryController(ControllerTest):
             destinations)
         self.controller.emailer.sent_out = []
 
-        # A human inspects the library, verifies that everything
+        # The document sent by the library registry to the library
+        # includes status information about the library's integration
+        # contact address -- information that wouldn't be made
+        # available to the public.
+        [link] = [x for x in catalog['links'] if
+                  x['rel'] == Hyperlink.INTEGRATION_CONTACT_REL]
+        eq_("mailto:me@library.org", link['href'])
+        eq_(Validation.IN_PROGRESS,
+            link['properties'][Validation.STATUS_PROPERTY])
+
+        # Now, a human inspects the library, verifies that everything
         # works, and makes it LIVE.
         library.stage = Library.LIVE
 

--- a/tests/test_controller.py
+++ b/tests/test_controller.py
@@ -637,22 +637,26 @@ class TestLibraryRegistryController(ControllerTest):
             response = self.controller.register(do_get=self.http_client.do_get)
             eq_(201, response.status_code)
 
-    def test_register_fails_on_no_contact_email(self):
-        with self.app.test_request_context("/", method="POST"):
-            flask.request.form = ImmutableMultiDict([
-                ("url", "http://circmanager.org/authentication.opds"),
-            ])
-            response = self.controller.register(do_get=self.http_client.do_get)
-            eq_("Invalid or missing configuration contact email address",
-                response.title)
+    # NOTE: This is commented out until we can say that registration
+    # requires providing a contact email and expect every new library
+    # to be on a circulation manager that can meet this requirement.
+    #
+    # def test_register_fails_on_no_contact_email(self):
+    #     with self.app.test_request_context("/", method="POST"):
+    #         flask.request.form = ImmutableMultiDict([
+    #             ("url", "http://circmanager.org/authentication.opds"),
+    #         ])
+    #         response = self.controller.register(do_get=self.http_client.do_get)
+    #         eq_("Invalid or missing configuration contact email address",
+    #             response.title)
 
-            flask.request.form = ImmutableMultiDict([
-                ("url", "http://circmanager.org/authentication.opds"),
-                ("contact", "http://contact-us/")
-            ])
-            response = self.controller.register(do_get=self.http_client.do_get)
-            eq_("Invalid or missing configuration contact email address",
-                response.title)
+    #         flask.request.form = ImmutableMultiDict([
+    #             ("url", "http://circmanager.org/authentication.opds"),
+    #             ("contact", "http://contact-us/")
+    #         ])
+    #         response = self.controller.register(do_get=self.http_client.do_get)
+    #         eq_("Invalid or missing configuration contact email address",
+    #             response.title)
 
     def test_register_fails_on_missing_email_in_authentication_document(self):
 

--- a/tests/test_opds.py
+++ b/tests/test_opds.py
@@ -2,12 +2,18 @@ from nose.tools import (
     eq_,
     set_trace,
 )
+import datetime
 import json
 
 from . import (
     DatabaseTest,
 )
 
+from model import (
+    get_one_or_create,
+    Hyperlink,
+    Validation,
+)
 from opds import OPDSCatalog
 
 class TestOPDSCatalog(DatabaseTest):
@@ -40,14 +46,36 @@ class TestOPDSCatalog(DatabaseTest):
         
     def test_library_catalog(self):
 
+        class Mock(OPDSCatalog):
+            """An OPDSCatalog that instruments calls to _hyperlink_args."""
+            hyperlinks = []
+
+            @classmethod
+            def _hyperlink_args(cls, hyperlink):
+                cls.hyperlinks.append(hyperlink)
+                return OPDSCatalog._hyperlink_args(hyperlink)
+
         library = self._library("The New York Public Library")
         library.urn = "123-abc"
         library.description = "It's a wonderful library."
         library.opds_url = "https://opds/"
         library.web_url = "https://nypl.org/"
         library.logo = "Fake logo"
+
+        # This email address is a secret between the library and the
+        # registry.
+        private_hyperlink, ignore = library.set_hyperlink(
+            Hyperlink.INTEGRATION_CONTACT_REL,
+            "mailto:secret@library.org"
+        )
+
+        # This email address is intended for public consumption.
+        public_hyperlink, ignore = library.set_hyperlink(
+            Hyperlink.HELP_REL,
+            "mailto:help@library.org"
+        )
         
-        catalog = OPDSCatalog.library_catalog(library)
+        catalog = Mock.library_catalog(library)
         metadata = catalog['metadata']
         eq_(library.name, metadata['title'])
         eq_(library.urn_uri, metadata['id'])
@@ -55,8 +83,11 @@ class TestOPDSCatalog(DatabaseTest):
 
         eq_(metadata['updated'], OPDSCatalog._strftime(library.timestamp))
 
-        [web, opds] = sorted(catalog['links'], key=lambda x: x['rel'])
+        [web, help, opds] = sorted(catalog['links'], key=lambda x: x['rel'])
         [logo] = catalog['images']
+
+        eq_("mailto:help@library.org", help['href'])
+        eq_(Hyperlink.HELP_REL, help['rel'])
 
         eq_(library.web_url, web['href'])
         eq_("alternate", web['rel'])
@@ -70,3 +101,59 @@ class TestOPDSCatalog(DatabaseTest):
         eq_(OPDSCatalog.THUMBNAIL_REL, logo['rel'])
         eq_("image/png", logo['type'])
 
+        # The public Hyperlink was passed into _hyperlink_args,
+        # which made it show up in the list of links.
+        #
+        # The private Hyperlink was not passed in.
+        eq_([public_hyperlink], Mock.hyperlinks)
+        Mock.hyperlinks = []
+
+        # If library_catalog is called with include_private_information=True,
+        # both Hyperlinks are passed into _hyperlink_args.
+        catalog = Mock.library_catalog(library, include_private_information=True)
+        eq_(set([public_hyperlink, private_hyperlink]), set(Mock.hyperlinks))
+
+    def test__hyperlink_args(self):
+        """Verify that _hyperlink_args generates arguments appropriate
+        for an OPDS 2 link.
+        """
+        m = OPDSCatalog._hyperlink_args
+
+        library = self._library()
+        hyperlink, is_new = library.set_hyperlink("some-rel", None)
+
+        # If there's not enough information to make a link,
+        # _hyperlink_args returns None.
+        eq_(None, m(None))
+        eq_(None, m(hyperlink))
+
+        # Now there's enough for a link, but there's no Validation.
+        hyperlink.href = "a url"
+        eq_(dict(href=hyperlink.href, rel=hyperlink.rel), m(hyperlink))
+
+        # Create a Validation.
+        validation, is_new = get_one_or_create(
+            self._db, Validation, resource=hyperlink.resource
+        )
+
+        def assert_reservation_status(expect):
+            args = m(hyperlink)
+            eq_(args['properties'][Validation.STATUS_PROPERTY], expect)
+
+        # Validation in progress
+        assert_reservation_status(Validation.IN_PROGRESS)
+
+        # Validation has expired
+        validation.started_at = datetime.datetime.utcnow()-datetime.timedelta(
+            days=365
+        )
+        assert_reservation_status(Validation.INACTIVE)
+
+        # Validation has been confirmed
+        validation.success = True
+        assert_reservation_status(Validation.CONFIRMED)
+
+        # If for some reason the Resource is removed from the Hyperlink,
+        # _hyperlink_args stops working.
+        hyperlink.resource = None
+        eq_(None, m(hyperlink))


### PR DESCRIPTION
This branch addresses https://jira.nypl.org/browse/SIMPLY-468. The OPDS catalog for a library will include links to email addresses that have a confirmation step, with information about where they are in the confirmation process.

I use https://schema.org/reservationStatus and https://schema.org/ReservationStatusType to talk about the process, rather than making up my own vocabulary, since the email confirmation process is equivalent to the process of confirming a reservation.

This branch also removes (by commenting out) the requirement that the `contact` email address be provided on initial registration. Because of the strategy we've chosen to phase out Accounts.json, we need to support an interim period where circulation managers that haven't been upgraded to send `contact` can register with the library registry anyway.