### PR TITLE
When the From: address is used in the body of an email, use only the email address

### DIFF
--- a/tests/test_emailer.py
+++ b/tests/test_emailer.py
@@ -235,7 +235,7 @@ The link will expire in about a day. If the link expires, just re-register your 
 
         emailer = MockEmailer.from_sitewide_integration(self._db)
         emailer.templates['email1'] = EmailTemplate(
-            "subject %(arg)s", "Hello, %(from_address)s."
+            "subject %(arg)s", "Hello, %(to_address)s, this is %(from_address)s."
         )
         mock_smtp = object()
 
@@ -250,7 +250,7 @@ The link will expire in about a day. If the link expires, just re-register your 
 To: you@library
 Subject: subject Value
 
-Hello, me@registry.""", body)
+Hello, you@library, this is me@registry""", body)
         eq_(mock_smtp, smtp)
 
     def test__send_email(self):

--- a/tests/test_emailer.py
+++ b/tests/test_emailer.py
@@ -235,7 +235,7 @@ The link will expire in about a day. If the link expires, just re-register your 
 
         emailer = MockEmailer.from_sitewide_integration(self._db)
         emailer.templates['email1'] = EmailTemplate(
-            "subject %(arg)s", "body %(arg)s"
+            "subject %(arg)s", "Hello, %(from_address)s."
         )
         mock_smtp = object()
 
@@ -250,7 +250,7 @@ The link will expire in about a day. If the link expires, just re-register your 
 To: you@library
 Subject: subject Value
 
-body Value""", body)
+Hello, me@registry.""", body)
         eq_(mock_smtp, smtp)
 
     def test__send_email(self):


### PR DESCRIPTION
This branch fixes a problem I noticed in emails sent out by the library registry, where the full value of the `From:` header was being substituted in as though it were an email address. This led to confusing phrases like "contact the Library Simplified support address at Library Registry Administrator <leonardrichardson@nypl.org>."

Now %(to_address)s and %(from_address)s will contain the email addresses whenever possible, with the full `From:` headers only being used as a backup. (I don't think that will happen in real usage.)
