### PR TITLE
Create local DelegatedIdentifier objects for Adobe IDs obtained from delegate servers

### DIFF
--- a/adobe_vendor_id.py
+++ b/adobe_vendor_id.py
@@ -225,6 +225,16 @@ class AdobeVendorIDModel(object):
             delegated_patron_identifier = None
         if delegated_patron_identifier:
             return self.account_id_and_label(delegated_patron_identifier)
+        else:
+            for delegate in self.short_client_token_decoder.delegates:
+                try:
+                    account_id, label, content = delegate.sign_in_standard(
+                        username, password
+                    )
+                    return account_id, label
+                except Exception, e:
+                    # This delegate couldn't help us.
+                    pass
 
         # Neither this server nor the delegates were able to do anything.
         return None, None
@@ -244,7 +254,18 @@ class AdobeVendorIDModel(object):
 
         if delegated_patron_identifier:
             return self.account_id_and_label(delegated_patron_identifier)
+        else:
+            for delegate in self.short_client_token_decoder.delegates:
+                try:
+                    account_id, label, content = delegate.sign_in_authdata(
+                        authdata
+                    )
+                    return account_id, label
+                except Exception, e:
+                    # This delegate couldn't help us.
+                    pass
 
+        # Neither this server nor the delegates were able to do anything.
         # We couldn't find anything.
         return None, None
 

--- a/adobe_vendor_id.py
+++ b/adobe_vendor_id.py
@@ -244,21 +244,6 @@ class AdobeVendorIDModel(object):
 
         if delegated_patron_identifier:
             return self.account_id_and_label(delegated_patron_identifier)
-        else:
-            # An authdata is opaque, so we can ask some other server
-            # to turn it into an account_id and label, but we we can't
-            # assume it's a short client token create a
-            # DelegatedPatronIdentifier for it. We don't know which
-            # library or which patron it's for.
-            for delegate in self.short_client_token_decoder.delegates:
-                try:
-                    account_id, label, content = delegate.sign_in_authdata(
-                        authdata
-                    )
-                    return account_id, label
-                except Exception, e:
-                    # This delegate couldn't help us.
-                    pass
 
         # We couldn't find anything.
         return None, None

--- a/model.py
+++ b/model.py
@@ -1642,6 +1642,9 @@ class ShortClientTokenDecoder(ShortClientTokenTool):
             except Exception, e:
                 # This delegate couldn't help us.
                 pass
+            if account_id:
+                # We got it -- no need to keep checking delegates.
+                break
 
         if not account_id:
             # The delegates couldn't help us; let's try to do it

--- a/model.py
+++ b/model.py
@@ -1624,7 +1624,7 @@ class ShortClientTokenDecoder(ShortClientTokenTool):
         """
         library = patron_identifier = account_id = None
 
-        # No matter how we do this, if we're going to create 
+        # No matter how we do this, if we're going to create
         # a DelegatedPatronIdentifier, we need to extract the Library
         # and the library's identifier for this patron from the 'username'
         # part of the token.

--- a/model.py
+++ b/model.py
@@ -1653,6 +1653,7 @@ class ShortClientTokenDecoder(ShortClientTokenTool):
                 signature = self.adobe_base64_decode(password)
             except Exception, e:
                 raise ValueError("Invalid password: %s" % password)
+
             patron_identifier, account_id = self._decode(
                 _db, username, signature
             )

--- a/tests/test_adobe_vendor_id.py
+++ b/tests/test_adobe_vendor_id.py
@@ -327,7 +327,8 @@ class TestVendorIDModel(VendorIDTest):
         eq_([], delegate1.queue)
         eq_([], delegate2.queue)
 
-        # Now test authentication by authdata.
+        # Now test authentication by treating the Short Client Token
+        # as authdata.
 
         # Delegate 1 can verify the authdata
         delegate1.enqueue(("userid", "label", "content"))
@@ -335,8 +336,9 @@ class TestVendorIDModel(VendorIDTest):
         # Delegate 2 is broken.
         delegate2.enqueue(VendorIDServerException("blah"))
 
-        result = model.authdata_lookup("some authdata")
-        eq_(("userid", "label"), result)
+        authdata = username + "|password"
+        result = model.authdata_lookup(authdata)
+        eq_(("userid", "Delegated account ID userid"), result)
 
         # We didn't even get to delegate 2.
         eq_(1, len(delegate2.queue))
@@ -344,7 +346,7 @@ class TestVendorIDModel(VendorIDTest):
         # If we try it again, we'll get an error from delegate 1,
         # since nothing is queued up, and then a queued error from
         # delegate 2.
-        result = model.authdata_lookup("some authdata")
+        result = model.authdata_lookup(authdata)
         eq_((None, None), result)
         eq_([], delegate2.queue)
 

--- a/tests/test_short_client_token.py
+++ b/tests/test_short_client_token.py
@@ -117,7 +117,7 @@ class TestShortClientTokenDecoder(DatabaseTest):
     def setup(self):
         super(TestShortClientTokenDecoder, self).setup()
         self.encoder = ShortClientTokenEncoder()
-        self.decoder = ShortClientTokenDecoder(self.TEST_NODE_VALUE)
+        self.decoder = ShortClientTokenDecoder(self.TEST_NODE_VALUE, [])
         self.library = self._library()
         self.library.short_name='LIBRARY'
         self.library.shared_secret='My shared secret'
@@ -231,8 +231,12 @@ class TestShortClientTokenDecoder(DatabaseTest):
         self.decoder._decode = _decode
 
         self.decoder.test_code_ran = False
+
+        # This username is good enough to fool
+        # ShortClientDecoder._split_token, but it won't work for real.
+        fake_username = "library|12345|username"
         self.decoder.decode_two_part(
-            self._db, "username", encoded_signature
+            self._db, fake_username, encoded_signature
         )
 
         # The code in _decode_short_client_token ran. Since there was no
@@ -242,5 +246,5 @@ class TestShortClientTokenDecoder(DatabaseTest):
         assert_raises_regexp(
             ValueError, "Invalid password",
             self.decoder.decode_two_part,
-            self._db, "username", "I am not a real encoded signature"
+            self._db, fake_username, "I am not a real encoded signature"
         )

--- a/tests/test_short_client_token.py
+++ b/tests/test_short_client_token.py
@@ -228,6 +228,7 @@ class TestShortClientTokenDecoder(DatabaseTest):
         def _decode(_db, token, supposed_signature):
             eq_(supposed_signature, signature)
             self.decoder.test_code_ran = True
+            return "identifier", "uuid"
         self.decoder._decode = _decode
 
         self.decoder.test_code_ran = False


### PR DESCRIPTION
Currently the AdobeVendorIDModel is responsible for keeping track of delegate servers. When it's asked to do a standard_lookup or an authdata_lookup, it asks the delegate servers first, and if they have an answer, it sends that answer to the client without doing anything else.

This leads to the race condition mentioned in https://jira.nypl.org/browse/SIMPLY-1047, which could cause people to lose their Adobe IDs as we change from having NYPL's circulation manager handle Adobe IDs, to having the library registry do it.

This branch gives responsibility for the delegate servers to the ShortClientTokenDecoder. When we're asked to decode a short client token, we ask the delegate servers to decode it first, and decode it ourselves if that doesn't work. Either way, we create a DelegatedPatronIdentifier containing the decoded information. This makes sure that if the delegation is removed, the lookup will succeed.

This introduces a number of assumptions that are theoretically problematic (which is why I didn't do things this way in the first place) but in practice should be fine. First, both the library registry and the delegate server need to know about the same libraries with the same short names and shared secrets. Otherwise the library registry will end up with Adobe IDs for libraries it can't actually validate itself.

Second, before this change we could have delegated lookups to any server; now we can only delegate to servers that understand Short Client Tokens, i.e. circulation managers.

These assumptions are fine, because the delegate system is only intended to manage the changeover from the circulation manager to the library registry. If we want to, we can go back to the old system after we switch over.