### PR TITLE
Raise a ValueError when asked to decode an empty token 

### DIFF
--- a/model.py
+++ b/model.py
@@ -1654,6 +1654,8 @@ class ShortClientTokenDecoder(ShortClientTokenTool):
 
         :raise ValueError: When the token is not valid for any reason.
         """
+        if not token:
+            raise ValueError("Cannot decode an empty token.")
         if not '|' in token:
             raise ValueError(
                 'Supposed client token "%s" does not contain a pipe.' % token

--- a/tests/test_adobe_vendor_id.py
+++ b/tests/test_adobe_vendor_id.py
@@ -288,6 +288,7 @@ class TestVendorIDModel(VendorIDTest):
             )
         )
 
+        eq_(None, None, self.model.authdata_lookup(None))
         eq_(None, None, self.model.authdata_lookup('badauthdata'))
 
         # This token is correctly formed but the signature doesn't match.

--- a/tests/test_short_client_token.py
+++ b/tests/test_short_client_token.py
@@ -157,6 +157,13 @@ class TestShortClientTokenDecoder(DatabaseTest):
 
         assert_raises_regexp(
             ValueError,
+            'Cannot decode an empty token.',
+            self.decoder.decode,
+            self._db, ""
+        )
+
+        assert_raises_regexp(
+            ValueError,
             'Supposed client token "no pipes" does not contain a pipe.',
             self.decoder.decode,
             self._db, "no pipes"


### PR DESCRIPTION
This appears to be the only change necessary to get the library registry responding correctly to realistic HTTP requests of the type made by Adobe's SDK (and Adobe's developers during certification).

This change is necessary to get `authdata_lookup` to give the appropriate error when the authdata is not provided -- it catches ValueError, so `token is None` needs to cause a ValueError. Checking `| in token` was causing a `TypeError`, which wasn't caught.