### PR TITLE
Send a problem detail document if a library can't be registered due to a problem with the SMTP server that's supposed to send out the validation email.

### DIFF
--- a/controller.py
+++ b/controller.py
@@ -7,6 +7,7 @@ from flask import (
     url_for,
 )
 import requests
+from smtplib import SMTPException
 import json
 import feedparser
 from Crypto.PublicKey import RSA
@@ -485,7 +486,14 @@ class LibraryRegistryController(object):
                 # what just happened. This is either so the receipient
                 # can confirm that the address works, or to inform
                 # them a new library is using their address.
-                hyperlink.notify(self.emailer, self.app.url_for)
+                try:
+                    hyperlink.notify(self.emailer, self.app.url_for)
+                except SMTPException, e:
+                    # We were unable to send the email.
+                    return INTEGRATION_ERROR.detailed(
+                        _("SMTP error while sending email to %(address)s",
+                          address=hyperlink.resource.href)
+                    )
 
         # Create an OPDS 2 catalog containing all available
         # information about the library.

--- a/problem_details.py
+++ b/problem_details.py
@@ -28,6 +28,12 @@ INTEGRATION_DOCUMENT_NOT_FOUND = pd(
     title=_("Document not found"),
 )
 
+INTEGRATION_ERROR = pd(
+    "http://librarysimplified.org/terms/problem/remote-integration-failed",
+    500,
+    title=_("Error with external integration"),
+)
+
 ERROR_RETRIEVING_DOCUMENT = pd(
     "http://librarysimplified.org/terms/problem/remote-integration-failed",
     502,


### PR DESCRIPTION
This was based on a conversation with Charles Horn of Internet Archive. Our library registry was configured with an email address that Amazon's SMTP server wouldn't accept as the `From:` address. For the time being I've changed the email address we use, but I also made this change so that if this problem happens again, the end-user will get a helpful error message instead of the server just crashing.