### PR TITLE
Allow registration to change an existing library's authentication_url if the registration form submission included the library's shared secret

### DIFF
--- a/controller.py
+++ b/controller.py
@@ -280,6 +280,7 @@ class LibraryRegistryController(object):
 
         integration_contact_uri = flask.request.form.get("contact")
         integration_contact_email = integration_contact_uri
+        shared_secret = flask.request.form.get("shared_secret")
 
         # If 'stage' is not provided, it means the client doesn't make the
         # testing/production distinction. We have to assume they want
@@ -426,10 +427,20 @@ class LibraryRegistryController(object):
             )
             return INVALID_INTEGRATION_DOCUMENT.detailed(failure_detail)
 
-        library, is_new = get_one_or_create(
-            self._db, Library,
-            opds_url=opds_url,
-        )
+        if shared_secret:
+            library = get_one (
+                self._db, Library,
+                shared_secret=shared_secret
+            )
+
+            if not library:
+                return AUTHENTICATION_FAILURE.detailed(
+                    "This library was not found in the system"
+                )
+
+
+
+
         try:
             library.library_stage = library_stage
         except ValueError, e:

--- a/controller.py
+++ b/controller.py
@@ -443,6 +443,7 @@ class LibraryRegistryController(object):
             )
             # This gives the requestor an elevated level of permissions.
             elevated_permissions = True
+            is_new = False
 
         if not library:
             # Either this is a library at a known authentication URL
@@ -455,11 +456,12 @@ class LibraryRegistryController(object):
                 library.opds_url = opds_url
 
         if elevated_permissions and library.authentication_url != auth_url:
-            # The library's URL has changed, e.g. because it moved
-            # from HTTP to HTTPS. The registration includes a valid
-            # shared secret, so it's okay to modify library.authentication_url.
-            result = self._update_library_url(
-                library, shared_secret, auth_url
+            # The library's authentication URL has changed,
+            # e.g. because it moved from HTTP to HTTPS. The
+            # registration includes a valid shared secret, so it's
+            # okay to modify library.authentication_url.
+            result = self._update_library_authentication_url(
+                library, auth_url, shared_secret
             )
             if isinstance(result, ProblemDetail):
                 return result
@@ -559,8 +561,11 @@ class LibraryRegistryController(object):
 
         return self.catalog_response(catalog, status_code)
 
-    def _update_library_url(self, library, new_authentication_url,
-                            provided_shared_secret):
+    @classmethod
+    def _update_library_authentication_url(
+            cls, library, new_authentication_url,
+            provided_shared_secret
+    ):
         """Change a library's authentication URL, assuming the provided shared
         secret gives the requester that permission.
 

--- a/controller.py
+++ b/controller.py
@@ -283,8 +283,7 @@ class LibraryRegistryController(object):
         shared_secret = None
         auth_header = flask.request.headers.get('Authorization')
         if auth_header and isinstance(auth_header, basestring) and "bearer" in auth_header.lower():
-            shared_secret = auth_header.split(' ')[1]
-
+            shared_secret = auth_header.split(' ', 1)[1]
 
         # If 'stage' is not provided, it means the client doesn't make the
         # testing/production distinction. We have to assume they want

--- a/problem_details.py
+++ b/problem_details.py
@@ -1,6 +1,12 @@
 from util.problem_detail import ProblemDetail as pd
 from flask_babel import lazy_gettext as _
 
+AUTHENTICATION_FAILURE = pd(
+    "http://librarysimplified.org/terms/problem/credentials-invalid",
+    401,
+    _("The library could not be authenticated.")
+)
+
 NO_AUTH_URL = pd(
       "http://librarysimplified.org/terms/problem/no-opds-auth-url",
       400,

--- a/testing.py
+++ b/testing.py
@@ -359,6 +359,7 @@ class DummyHTTPResponse(object):
         self.content = content
         self.links = links or {}
         self.url = url or "http://url/"
+        self.final_url = self.url
 
     @property
     def raw(self):
@@ -371,14 +372,18 @@ class DummyHTTPClient(object):
         self.requests = []
 
     def queue_response(self, response_code, media_type="text/html",
-                       other_headers=None, content='', links=None):
+                       other_headers=None, content='', links=None,
+                       url=None
+    ):
         headers = {}
         if media_type:
             headers["Content-Type"] = media_type
         if other_headers:
             for k, v in other_headers.items():
                 headers[k.lower()] = v
-        self.responses.insert(0, DummyHTTPResponse(response_code, headers, content, links))
+        self.responses.insert(
+            0, DummyHTTPResponse(response_code, headers, content, links, url)
+        )
 
     def do_get(self, url, headers=None, allowed_response_codes=None, **kwargs):
         self.requests.append(url)

--- a/tests/test_controller.py
+++ b/tests/test_controller.py
@@ -432,9 +432,8 @@ class TestLibraryRegistryController(ControllerTest):
             eq_('No Authentication For OPDS document present at http://circmanager.org/authentication.opds', response.detail)
 
     def test_register_fails_on_non_authentication_document(self):
-        """The request succeeds but returns something other than
-        an authentication document.
-        """
+        # The request succeeds but returns something other than
+        # an authentication document.
         self.http_client.queue_response(
             200, content="I am not an Authentication For OPDS document."
         )
@@ -444,28 +443,32 @@ class TestLibraryRegistryController(ControllerTest):
             eq_(INVALID_INTEGRATION_DOCUMENT, response)
 
     def test_register_fails_on_non_matching_id(self):
-        """The request returns an authentication document but its `id`
-        doesn't match the URL it was retrieved from.
-        """
+        # The request returns an authentication document but its `id`
+        # doesn't match the final URL it was retrieved from.
         auth_document = self._auth_document()
-        self.http_client.queue_response(200, content=json.dumps(auth_document))
+        self.http_client.queue_response(
+            200, content=json.dumps(auth_document),
+            url="http://a-different-url/"
+        )
         with self.app.test_request_context("/", method="POST"):
             flask.request.form = ImmutableMultiDict([
                 ("url", "http://a-different-url/"),
                 ("contact", "mailto:me@library.org"),
             ])
             response = self.controller.register(do_get=self.http_client.do_get)
+
             eq_(INVALID_INTEGRATION_DOCUMENT.uri, response.uri)
             eq_("The OPDS authentication document's id (http://circmanager.org/authentication.opds) doesn't match its url (http://a-different-url/).",
                 response.detail)
 
     def test_register_fails_on_missing_title(self):
-        """The request returns an authentication document but it's missing
-        a title.
-        """
+        # The request returns an authentication document but it's missing
+        # a title.
         auth_document = self._auth_document()
         del auth_document['title']
-        self.http_client.queue_response(200, content=json.dumps(auth_document))
+        self.http_client.queue_response(
+            200, content=json.dumps(auth_document), url=auth_document['id']
+        )
         with self.app.test_request_context("/", method="POST"):
             flask.request.form = self.registration_form
             response = self.controller.register(do_get=self.http_client.do_get)
@@ -474,14 +477,15 @@ class TestLibraryRegistryController(ControllerTest):
                 response.detail)
 
     def test_register_fails_on_no_start_link(self):
-        """The request returns an authentication document but it's missing
-        a link to an OPDS feed.
-        """
+        # The request returns an authentication document but it's missing
+        # a link to an OPDS feed.
         auth_document = self._auth_document()
         for link in list(auth_document['links']):
             if link['rel'] == 'start':
                 auth_document['links'].remove(link)
-        self.http_client.queue_response(200, content=json.dumps(auth_document))
+        self.http_client.queue_response(
+            200, content=json.dumps(auth_document), url=auth_document['id']
+        )
         with self.app.test_request_context("/", method="POST"):
             flask.request.form = self.registration_form
             response = self.controller.register(do_get=self.http_client.do_get)
@@ -490,11 +494,13 @@ class TestLibraryRegistryController(ControllerTest):
                 response.detail)
 
     def test_register_fails_on_start_link_not_found(self):
-        """The request returns an authentication document but an attempt
-        to retrieve the corresponding OPDS feed yields a 404.
-        """
+        # The request returns an authentication document but an attempt
+        # to retrieve the corresponding OPDS feed yields a 404.
         auth_document = self._auth_document()
-        self.http_client.queue_response(200, content=json.dumps(auth_document))
+        self.http_client.queue_response(
+            200, content=json.dumps(auth_document),
+            url=auth_document['id']
+        )
         self.http_client.queue_response(404)
         with self.app.test_request_context("/", method="POST"):
             flask.request.form = self.registration_form
@@ -504,11 +510,12 @@ class TestLibraryRegistryController(ControllerTest):
                 response.detail)
 
     def test_register_fails_on_start_link_timeout(self):
-        """The request returns an authentication document but an attempt
-        to retrieve the corresponding OPDS feed times out.
-        """
+        # The request returns an authentication document but an attempt
+        # to retrieve the corresponding OPDS feed times out.
         auth_document = self._auth_document()
-        self.http_client.queue_response(200, content=json.dumps(auth_document))
+        self.http_client.queue_response(
+            200, content=json.dumps(auth_document), url=auth_document['id']
+        )
         self.http_client.queue_response(RequestTimedOut("http://url", "sorry"))
         with self.app.test_request_context("/", method="POST"):
             flask.request.form = self.registration_form
@@ -518,11 +525,12 @@ class TestLibraryRegistryController(ControllerTest):
                 response.detail)
 
     def test_register_fails_on_start_link_error(self):
-        """The request returns an authentication document but an attempt
-        to retrieve the corresponding OPDS feed gives a server-side error.
-        """
+        # The request returns an authentication document but an attempt
+        # to retrieve the corresponding OPDS feed gives a server-side error.
         auth_document = self._auth_document()
-        self.http_client.queue_response(200, content=json.dumps(auth_document))
+        self.http_client.queue_response(
+            200, content=json.dumps(auth_document), url=auth_document['id']
+        )
         self.http_client.queue_response(500)
         with self.app.test_request_context("/", method="POST"):
             flask.request.form = self.registration_form
@@ -535,7 +543,9 @@ class TestLibraryRegistryController(ControllerTest):
         to retrieve the corresponding OPDS feed gives a server-side error.
         """
         auth_document = self._auth_document()
-        self.http_client.queue_response(200, content=json.dumps(auth_document))
+        self.http_client.queue_response(
+            200, content=json.dumps(auth_document), url=auth_document['id']
+        )
 
         # The start link returns a 200 response code but the wrong
         # Content-Type.
@@ -548,12 +558,16 @@ class TestLibraryRegistryController(ControllerTest):
 
     def test_register_fails_if_start_link_does_not_link_back_to_auth_document(self):
         auth_document = self._auth_document()
-        self.http_client.queue_response(200, content=json.dumps(auth_document))
+        self.http_client.queue_response(
+            200, content=json.dumps(auth_document), url=auth_document['id']
+        )
 
         # The start link returns a 200 response code and the right
         # Content-Type, but there is no Link header and the body is no
         # help.
-        self.http_client.queue_response(200, OPDSCatalog.OPDS_TYPE, content='{}')
+        self.http_client.queue_response(
+            200, OPDSCatalog.OPDS_TYPE, content='{}'
+        )
         with self.app.test_request_context("/", method="POST"):
             flask.request.form = self.registration_form
             response = self.controller.register(do_get=self.http_client.do_get)
@@ -570,7 +584,9 @@ class TestLibraryRegistryController(ControllerTest):
                 link['href'] = "http://example.com/broken-logo.png"
                 break
         # Auth document request succeeds.
-        self.http_client.queue_response(200, content=json.dumps(auth_document))
+        self.http_client.queue_response(
+            200, content=json.dumps(auth_document), url=auth_document['id']
+        )
 
         # OPDS feed request succeeds.
         self.queue_opds_success()
@@ -593,7 +609,7 @@ class TestLibraryRegistryController(ControllerTest):
             flask.request.form = self.registration_form
             auth_document = self._auth_document()
             auth_document['service_area'] = {"US": ["Somewhere"]}
-            self.http_client.queue_response(200, content=json.dumps(auth_document))
+            self.http_client.queue_response(200, content=json.dumps(auth_document), url=auth_document['id'])
             self.queue_opds_success()
             response = self.controller.register(do_get=self.http_client.do_get)
             eq_(INVALID_INTEGRATION_DOCUMENT.uri, response.uri)
@@ -604,7 +620,10 @@ class TestLibraryRegistryController(ControllerTest):
             flask.request.form = self.registration_form
             auth_document = self._auth_document()
             auth_document['service_area'] = {"US": ["Manhattan"]}
-            self.http_client.queue_response(200, content=json.dumps(auth_document))
+            self.http_client.queue_response(
+                200, content=json.dumps(auth_document),
+                url=auth_document['id']
+            )
             self.queue_opds_success()
             response = self.controller.register(do_get=self.http_client.do_get)
             eq_(INVALID_INTEGRATION_DOCUMENT.uri, response.uri)
@@ -614,7 +633,9 @@ class TestLibraryRegistryController(ControllerTest):
         with self.app.test_request_context("/", method="POST"):
             flask.request.form = self.registration_form
             auth_document = self._auth_document()
-            self.http_client.queue_response(200, content=json.dumps(auth_document))
+            self.http_client.queue_response(
+                200, content=json.dumps(auth_document), url=auth_document['id']
+            )
             self.http_client.queue_response(401)
             response = self.controller.register(do_get=self.http_client.do_get)
             eq_(INVALID_INTEGRATION_DOCUMENT.uri, response.uri)
@@ -624,11 +645,16 @@ class TestLibraryRegistryController(ControllerTest):
         with self.app.test_request_context("/", method="POST"):
             flask.request.form = self.registration_form
             auth_document = self._auth_document()
-            self.http_client.queue_response(200, content=json.dumps(auth_document))
+            self.http_client.queue_response(
+                200, content=json.dumps(auth_document),
+                url=auth_document['id']
+            )
             auth_document['id'] = "http://some-other-id/"
             self.http_client.queue_response(
-                401, AuthenticationDocument.MEDIA_TYPE, content=json.dumps(auth_document
-            ))
+                401, AuthenticationDocument.MEDIA_TYPE,
+                content=json.dumps(auth_document),
+                url=auth_document['id']
+            )
 
             response = self.controller.register(do_get=self.http_client.do_get)
             eq_(INVALID_INTEGRATION_DOCUMENT.uri, response.uri)
@@ -638,10 +664,15 @@ class TestLibraryRegistryController(ControllerTest):
         with self.app.test_request_context("/", method="POST"):
             flask.request.form = self.registration_form
             auth_document = self._auth_document()
-            self.http_client.queue_response(200, content=json.dumps(auth_document))
             self.http_client.queue_response(
-                401, AuthenticationDocument.MEDIA_TYPE, content=json.dumps(auth_document
-            ))
+                200, content=json.dumps(auth_document),
+                url=auth_document['id']
+            )
+            self.http_client.queue_response(
+                401, AuthenticationDocument.MEDIA_TYPE,
+                content=json.dumps(auth_document),
+                url=auth_document['id']
+            )
 
             response = self.controller.register(do_get=self.http_client.do_get)
             eq_(201, response.status_code)
@@ -684,7 +715,10 @@ class TestLibraryRegistryController(ControllerTest):
             )
 
             def _request_fails():
-                self.http_client.queue_response(200, content=json.dumps(auth_document))
+                self.http_client.queue_response(
+                    200, content=json.dumps(auth_document),
+                    url=auth_document['id']
+                )
                 with self.app.test_request_context("/", method="POST"):
                     flask.request.form = self.registration_form
                     response = self.controller.register(do_get=self.http_client.do_get)
@@ -703,7 +737,9 @@ class TestLibraryRegistryController(ControllerTest):
         # Pretend we are a library with a valid authentication document.
         key = RSA.generate(1024)
         auth_document = self._auth_document(key)
-        self.http_client.queue_response(200, content=json.dumps(auth_document))
+        self.http_client.queue_response(
+            200, content=json.dumps(auth_document), url=auth_document['id']
+        )
         self.queue_opds_success()
 
         auth_url = "http://circmanager.org/authentication.opds"
@@ -717,7 +753,6 @@ class TestLibraryRegistryController(ControllerTest):
                 ("contact", "mailto:me@library.org"),
             ])
             response = self.controller.register(do_get=self.http_client.do_get)
-
             eq_(201, response.status_code)
             eq_(opds_directory, response.headers.get("Content-Type"))
 
@@ -827,7 +862,9 @@ class TestLibraryRegistryController(ControllerTest):
             ],
             "service_area": { "US": "Connecticut" },
         }
-        self.http_client.queue_response(200, content=json.dumps(auth_document))
+        self.http_client.queue_response(
+            200, content=json.dumps(auth_document), url=auth_document['id']
+        )
         self.queue_opds_success()
 
         # We have a new logo as well.
@@ -926,7 +963,9 @@ class TestLibraryRegistryController(ControllerTest):
 
             key = RSA.generate(1024)
             auth_document = self._auth_document(key)
-            self.http_client.queue_response(200, content=json.dumps(auth_document))
+            self.http_client.queue_response(
+                200, content=json.dumps(auth_document), url=auth_document['id']
+            )
             self.queue_opds_success()
 
             response = self.controller.register(do_get=self.http_client.do_get)

--- a/tests/test_controller.py
+++ b/tests/test_controller.py
@@ -998,6 +998,36 @@ class TestLibraryRegistryController(ControllerTest):
             eq_(200, response.status_code)
             eq_(old_secret, library.shared_secret)
 
+    def test_register_with_secret_changes_authentication_url(self):
+        # This Library was created previously with a certain shared
+        # secret, at a URL that's no longer valid.
+        secret = "it's a secret"
+        library = self._library()
+        library.authentication_url = "http://old-url/"
+        library.shared_secret = secret
+
+        # We're going to register a library at an apparently new URL,
+        # but since we're providing the shared secret for an existing
+        # Library, the registry will know to modify that Library instead
+        # of creating a new one.
+        auth_document = self._auth_document()
+        new_auth_url = auth_document['id']
+        self.http_client.queue_response(
+            200, content=json.dumps(auth_document), url=new_auth_url
+        )
+        self.queue_opds_success()
+        with self.app.test_request_context("/", method="POST"):
+            flask.request.form = ImmutableMultiDict([
+                ("url", new_auth_url),
+                ("shared_secret", secret)
+            ])
+            response = self.controller.register(do_get=self.http_client.do_get)
+            # No new library was created.
+            eq_(200, response.status_code)
+
+        # The library's authentication_url has been modified.
+        eq_(new_auth_url, library.authentication_url)
+
     def test_opds_response_links(self):
         """Test the opds_response_links method.
 
@@ -1200,6 +1230,24 @@ class TestLibraryRegistryController(ControllerTest):
         result = m("rel2", links, "a title")
         eq_(["mailto:me@library.org", "mailto:me2@library.org"], result)
 
+    def test__update_library_authentication_url(self):
+        """Test the code that modifies Library.authentication_url
+        if the right shared secret was provided.
+        """
+        library = self._library()
+        secret = "it's a secret"
+        library.shared_secret = secret
+        library.authentication_url = "old value"
+
+        m = LibraryRegistryController._update_library_authentication_url
+        problem = m(library, "new value", "wrong secret")
+        eq_(AUTHENTICATION_FAILURE.uri, problem.uri)
+        eq_("Provided shared secret is invalid", problem.detail)
+        eq_("old value", library.authentication_url)
+
+        result = m(library, "new value", secret)
+        eq_(result, None)
+        eq_("new value", library.authentication_url)
 
 class TestValidationController(ControllerTest):
 

--- a/tests/test_controller.py
+++ b/tests/test_controller.py
@@ -1017,9 +1017,11 @@ class TestLibraryRegistryController(ControllerTest):
         )
         self.queue_opds_success()
         with self.app.test_request_context("/", method="POST"):
+            flask.request.headers = {
+                "Authorization": "Bearer %s" % secret
+            }
             flask.request.form = ImmutableMultiDict([
                 ("url", new_auth_url),
-                ("shared_secret", secret)
             ])
             response = self.controller.register(do_get=self.http_client.do_get)
             # No new library was created.


### PR DESCRIPTION
This partially addresses https://jira.nypl.org/browse/SIMPLY-1031. There will also be a circulation branch that starts sending the shared secret as part of registration.