### PR TITLE
Fix the confirmation workflow, which was broken in several places.

### DIFF
--- a/app.py
+++ b/app.py
@@ -88,8 +88,8 @@ def search_qa():
 
 @app.route('/confirm/<int:resource_id>/<secret>')
 @returns_problem_detail
-def confirm_resource(secret):
-    return app.library_registry.validation_controller.validate(
+def confirm_resource(resource_id, secret):
+    return app.library_registry.validation_controller.confirm(
         resource_id, secret
     )
 

--- a/controller.py
+++ b/controller.py
@@ -76,6 +76,8 @@ class LibraryRegistry(object):
         self.registry_controller = LibraryRegistryController(
             self, emailer_class
         )
+        self.validation_controller = ValidationController(self)
+
         self.heartbeat = HeartbeatController()
         vendor_id, node_value, delegates = Configuration.vendor_id(self._db)
         if vendor_id:

--- a/tests/test_controller.py
+++ b/tests/test_controller.py
@@ -43,7 +43,7 @@ from problem_details import *
 from config import Configuration
 from testing import DummyHTTPResponse
 
-class TestLibraryRegistry(LibraryRegistry):
+class MockLibraryRegistry(LibraryRegistry):
     pass
 
 class MockEmailer(Emailer):
@@ -67,7 +67,7 @@ class ControllerTest(DatabaseTest):
         del os.environ['AUTOINITIALIZE']
         self.app = app
         self.data_setup()
-        self.library_registry = TestLibraryRegistry(
+        self.library_registry = MockLibraryRegistry(
             self._db, testing=True, emailer_class=MockEmailer,
         )
         self.app.library_registry = self.library_registry
@@ -78,6 +78,43 @@ class ControllerTest(DatabaseTest):
         object.
         """
         pass
+
+    def vendor_id_setup(self):
+        """Configure a basic vendor id service."""
+        integration, ignore = get_one_or_create(
+            self._db, ExternalIntegration,
+            protocol=ExternalIntegration.ADOBE_VENDOR_ID,
+            goal=ExternalIntegration.DRM_GOAL,
+        )
+        integration.setting(Configuration.ADOBE_VENDOR_ID).value = "VENDORID"
+
+
+class TestLibraryRegistry(ControllerTest):
+
+    def test_instantiated_controllers(self):
+        # Verify that the controllers were instantiated and attached
+        # to the LibraryRegistry object.
+        assert isinstance(
+            self.library_registry.registry_controller,
+            LibraryRegistryController
+        )
+        assert isinstance(
+            self.library_registry.validation_controller,
+            ValidationController
+        )
+
+        # No Adobe Vendor ID was set up.
+        eq_(None, self.library_registry.adobe_vendor_id)
+
+        # Let's configure one.
+        self.vendor_id_setup()
+        registry_with_adobe = MockLibraryRegistry(
+            self._db, testing=True, emailer_class=MockEmailer
+        )
+        assert isinstance(
+            registry_with_adobe.adobe_vendor_id,
+            AdobeVendorIDController
+        )
 
 
 class TestLibraryRegistryController(ControllerTest):
@@ -96,13 +133,7 @@ class TestLibraryRegistryController(ControllerTest):
         manhattan_ks = self.manhattan_ks
         us = self.crude_us
 
-        # Configure a basic vendor id service.
-        integration, ignore = get_one_or_create(
-            self._db, ExternalIntegration,
-            protocol=ExternalIntegration.ADOBE_VENDOR_ID,
-            goal=ExternalIntegration.DRM_GOAL,
-        )
-        integration.setting(Configuration.ADOBE_VENDOR_ID).value = "VENDORID"
+        self.vendor_id_setup()
 
     def setup(self):
         super(TestLibraryRegistryController, self).setup()

--- a/tests/test_controller.py
+++ b/tests/test_controller.py
@@ -11,6 +11,7 @@ from smtplib import SMTPException
 from urllib import unquote
 
 from controller import (
+    AdobeVendorIDController,
     LibraryRegistry,
     LibraryRegistryController,
     ValidationController,


### PR DESCRIPTION
This branch fixes a number of problems with the email confirmation workflow, all of them located in untested routing code.

* The `confirm_resource` function took the wrong arguments.
* It referred to a `LibraryRegistry.validation_controller` object, but that object was not instantiated during startup.
* It called the method `ValidationController.validate` when the actual name of the method is `confirm`.

I've done an end-to-end test locally to make sure there are no more problems with this process.