### PR TITLE
Changed final_url back to url (final_url only worked in tests).

### DIFF
--- a/controller.py
+++ b/controller.py
@@ -396,8 +396,8 @@ class LibraryRegistryController(object):
         else:
             failure_detail = _("The OPDS authentication document is missing a 'start' link to the root OPDS feed.")
 
-        if auth_document.id != auth_response.final_url:
-            failure_detail = _("The OPDS authentication document's id (%(id)s) doesn't match its url (%(url)s).", id=auth_document.id, url=auth_response.final_url)
+        if auth_document.id != auth_response.url:
+            failure_detail = _("The OPDS authentication document's id (%(id)s) doesn't match its url (%(url)s).", id=auth_document.id, url=auth_response.url)
         if failure_detail:
             self.log.error(
                 "Registration of %s failed: %s", auth_url, failure_detail
@@ -457,7 +457,7 @@ class LibraryRegistryController(object):
 
         library = None
         elevated_permissions = False
-        auth_url = auth_response.final_url
+        auth_url = auth_response.url
         if shared_secret:
             # Look up a library by the provided shared secret. This
             # will let us handle the case where the library has

--- a/testing.py
+++ b/testing.py
@@ -359,7 +359,6 @@ class DummyHTTPResponse(object):
         self.content = content
         self.links = links or {}
         self.url = url or "http://url/"
-        self.final_url = self.url
 
     @property
     def raw(self):


### PR DESCRIPTION
We talked about this a while ago but I never committed it. I didn't end up needing to change any tests - `url` was already getting set and everything still worked.