### PR TITLE
Speed up and improve reliability for Place.lookup_inside

### DIFF
--- a/testing.py
+++ b/testing.py
@@ -235,12 +235,12 @@ class DatabaseTest(object):
     @property
     def new_york_state(self):
         return self._place('36', 'New York', Place.STATE,
-                           'NY', None, self.new_york_state_geojson)
+                           'NY', self.crude_us, self.new_york_state_geojson)
 
     @property
     def connecticut_state(self):
         return self._place('09', 'Connecticut', Place.STATE,
-                           'CT', None, self.connecticut_state_geojson)
+                           'CT', self.crude_us, self.connecticut_state_geojson)
 
     @property
     def new_york_city(self):
@@ -272,12 +272,17 @@ class DatabaseTest(object):
     @property
     def kansas_state(self):
         return self._place('20', 'Kansas', Place.STATE,
-                           'KS', None, self.kansas_state_geojson)
+                           'KS', self.crude_us, self.kansas_state_geojson)
+
+    @property
+    def massachussets_state(self):
+        return self._place('25', 'Massachussets', Place.STATE,
+                           'MA', self.crude_us, None)
 
     @property
     def boston_ma(self):
         return self._place('2507000', 'Boston', Place.CITY,
-                           None, None,
+                           None, self.massachussets_state,
                            self.boston_geojson)
 
     @property
@@ -313,7 +318,7 @@ class DatabaseTest(object):
     @property
     def new_mexico_state(self):
         return self._place('NM', 'New Mexico', Place.STATE,
-                           'NM', None, self.new_mexico_state_geojson)
+                           'NM', self.crude_us, self.new_mexico_state_geojson)
 
     @property
     def crude_new_york_county(self):

--- a/tests/test_controller.py
+++ b/tests/test_controller.py
@@ -723,6 +723,13 @@ class TestLibraryRegistryController(ControllerTest):
             eq_("The following service area was unknown: {\"US\": [\"Somewhere\"]}.", response.detail)
 
     def test_register_fails_on_ambiguous_service_area(self):
+
+        # Create a situation (which shouldn't exist in real life)
+        # where there are two places with the same name and the same
+        # .parent.
+        self.new_york_city.parent = self.crude_us
+        self.manhattan_ks.parent = self.crude_us
+
         with self.app.test_request_context("/", method="POST"):
             flask.request.form = self.registration_form
             auth_document = self._auth_document()

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -195,6 +195,11 @@ class TestPlace(DatabaseTest):
         lookup_both_ways(connecticut, "New York, NY", None)
         lookup_both_ways(connecticut, "10018", None)
 
+        # Even though the parent of a ZIP code is a state, special
+        # code allows you to look them up within the nation.
+        lookup_both_ways(us, "10018", zip_10018)
+        lookup_both_ways(new_york, "10018", zip_10018)
+
         # You can't find a place 'inside' itself.
         lookup_both_ways(us, "US", None)
         lookup_both_ways(new_york, "NY, US, 10018", None)
@@ -219,12 +224,6 @@ class TestPlace(DatabaseTest):
             kings_county,
             everywhere.lookup_inside("Kings County, US", using_overlap=True)
         )
-
-        # Looking up a ZIP code without the context of its state is
-        # only possible with using_overlap=True. We can change this by
-        # changing it so that the parent of a ZIP code is the nation.
-        eq_(zip_10018, us.lookup_inside("10018", using_overlap=True))
-        eq_(None, us.lookup_inside("10018", using_overlap=False))
 
         # Neither of these is obviously better.
         eq_(None, us.lookup_inside("Manhattan"))

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -205,8 +205,9 @@ class TestPlace(DatabaseTest):
         lookup_both_ways(zip_10018, "NY", None)
 
         # Now test cases where using_overlap makes a difference.
-
+        #
         # First, the cases where using_overlap=True performs better.
+        #
 
         # Looking up the name of a county by itself only works with
         # using_overlap=True, because the .parent of a county is its
@@ -218,6 +219,12 @@ class TestPlace(DatabaseTest):
             kings_county,
             everywhere.lookup_inside("Kings County, US", using_overlap=True)
         )
+
+        # Looking up a ZIP code without the context of its state is
+        # only possible with using_overlap=True. We can change this by
+        # changing it so that the parent of a ZIP code is the nation.
+        eq_(zip_10018, us.lookup_inside("10018", using_overlap=True))
+        eq_(None, us.lookup_inside("10018", using_overlap=False))
 
         # Neither of these is obviously better.
         eq_(None, us.lookup_inside("Manhattan"))


### PR DESCRIPTION
Currently `Place.lookup_inside` uses comparison of shapefiles to look up a place inside another place (such as California within the United States, or Kern County within California, or 93203 within Kern County). This is very powerful but it also has big problems.

* It's very slow.

* It fails in common cases. It can't parse "New York, New York" because it can't tell whether the first "New York" is referring to New York City or New York State. It can't parse "Santa Barbara, CA" because California has both a city and a county called Santa Barbara. (In real life, anyone wanting to refer to the county would say "Santa Barbara County, CA".)

* Most of the power is for cases that no real person would use. We wouldn't say "93203, Kern County, California", because "93203" is unambiguous on its own. We wouldn't say "Bakersfield, Kern County, California" -- we would use city and state, the way we do when addressing a letter. We wouldn't say "Chicago, US" because it's redundant.

* You can look up a smaller place inside a larger one (e.g. the United States within California), because it compares the intersection of shapefiles, rather than checking that one contains the other.

This branch changes what it means for a place to be "inside" another place for purposes of `Place.lookup_inside`. Now, place A is inside place B only if `A.parent == B`. It works because we set up `.parent` to correspond to the way real people think about places. In particular, the parent of a city is its state, not its county. (The parent of a postal code is its state, and I think we might need to change that to be the nation so that you can just say "93203" instead of "93203, CA".)

The old behavior is preserved in case we need it for anything, but I think we'll find that we don't.

This is work towards https://jira.nypl.org/browse/SIMPLY-1044 but I don't think it entirely resolves that issue.