### PR TITLE
Allow registries to define a default nation which is used when processing incoming place names that don't mention one

### DIFF
--- a/authentication_document.py
+++ b/authentication_document.py
@@ -173,52 +173,52 @@ class AuthenticationDocument(object):
             coverage = dict() # Do no more processing
 
         elif not isinstance(coverage, dict):
-            # The coverage is not in { country: place } format.
-            # Convert it into that format using the default country.
-            default_country = place_class.default_country(_db)
-            if default_country:
-                coverage = {default_country.abbreviated_name : coverage }
+            # The coverage is not in { nation: place } format.
+            # Convert it into that format using the default nation.
+            default_nation = place_class.default_nation(_db)
+            if default_nation:
+                coverage = {default_nation.abbreviated_name : coverage }
             else:
                 # Oops, that's not going to work. We don't know which
-                # country this place is in. Return a coverage object
+                # nation this place is in. Return a coverage object
                 # that makes it semi-clear what the problem is.
                 unknown["??"] = coverage
                 coverage = dict() # Do no more processing
 
-        for country, places in coverage.items():
+        for nation, places in coverage.items():
             try:
-                country_obj = place_class.lookup_one_by_name(
-                    _db, country, place_type=Place.NATION,
+                nation_obj = place_class.lookup_one_by_name(
+                    _db, nation, place_type=Place.NATION,
                 )
                 if places == cls.COVERAGE_EVERYWHERE:
-                    # This library covers an entire country.
-                    place_objs.append(country_obj)
+                    # This library covers an entire nation.
+                    place_objs.append(nation_obj)
                 else:
                     # This library covers a list of places within a
-                    # country.
+                    # nation.
                     if isinstance(places, basestring):
                         # This is invalid -- you're supposed to always
                         # pass in a list -- but we can support it.
                         places = [places]
                     for place in places:
                         try:
-                            place_obj = country_obj.lookup_inside(place)
+                            place_obj = nation_obj.lookup_inside(place)
                             if place_obj:
                                 # We found it.
                                 place_objs.append(place_obj)
                             else:
                                 # We couldn't find any place with this name.
-                                unknown[country].append(place)
+                                unknown[nation].append(place)
                         except MultipleResultsFound, e:
                             # The place was ambiguously named.
-                            ambiguous[country].append(place)
+                            ambiguous[nation].append(place)
             except MultipleResultsFound, e:
-                # A country was ambiguously named -- not very likely.
-                ambiguous[country] = places
+                # A nation was ambiguously named -- not very likely.
+                ambiguous[nation] = places
             except NoResultFound, e:
-                # Either this isn't a recognized country
+                # Either this isn't a recognized nation
                 # or we don't have a geography for it.
-                unknown[country] = places
+                unknown[nation] = places
         return place_objs, unknown, ambiguous
 
     @classmethod

--- a/authentication_document.py
+++ b/authentication_document.py
@@ -177,13 +177,13 @@ class AuthenticationDocument(object):
             # Convert it into that format using the default country.
             default_country = place_class.default_country(_db)
             if default_country:
+                coverage = {default_country.abbreviated_name : coverage }
+            else:
                 # Oops, that's not going to work. We don't know which
                 # country this place is in. Return a coverage object
                 # that makes it semi-clear what the problem is.
                 unknown["??"] = coverage
                 coverage = dict() # Do no more processing
-            else:
-                coverage = {default_country.abbreviated_name : coverage }
 
         for country, places in coverage.items():
             try:

--- a/config.py
+++ b/config.py
@@ -53,8 +53,8 @@ class Configuration(object):
     WEB_CLIENT_URL = "web_client_url"
 
     # If a library references a place that's not explicitly in any particular
-    # country, we assume that they're talking about this country.
-    DEFAULT_COUNTRY_NAME = "default_country_name"
+    # nation, we assume that they're talking about this nation.
+    DEFAULT_NATION_ABBREVIATION = "default_nation_abbreviation"
 
     @classmethod
     def database_url(cls, test=False):

--- a/config.py
+++ b/config.py
@@ -52,6 +52,10 @@ class Configuration(object):
     # a `{uuid}` expression, to provide the web URL for a specific library.
     WEB_CLIENT_URL = "web_client_url"
 
+    # If a library references a place that's not explicitly in any particular
+    # country, we assume that they're talking about this country.
+    DEFAULT_COUNTRY_NAME = "default_country_name"
+
     @classmethod
     def database_url(cls, test=False):
         """Find the URL to the database so that other configuration

--- a/model.py
+++ b/model.py
@@ -1068,13 +1068,10 @@ class Place(Base):
     def default_country(cls, _db):
         """Return the default country for this library registry.
 
-        If an incoming place name doesn't mention a country, we'll try
-        to look it up within this country. If this is set, it's
-        probably to the name of the country in which this registry is
-        based.
+        If an incoming coverage area doesn't mention a country, we'll
+        assume it's within this country.
 
-        :return: The default country, if one is named and the name can
-            be processed. Otherwise, None.
+        :return: The default country, if one can be found. Otherwise, None.
         """
         default_country = None
         country_name=ConfigurationSetting.sitewide(
@@ -1087,6 +1084,11 @@ class Place(Base):
                 self.logging.error(
                     "Could not look up default country %s", country_name
                 )
+            if default_country.type != Place.COUNTRY:
+                self.logging.error(
+                    "Default country %s is not a country!", country_name
+                )
+                default_country = None
         return default_country
 
     @classmethod

--- a/model.py
+++ b/model.py
@@ -1088,44 +1088,6 @@ class Place(Base):
         return default_nation
 
     @classmethod
-    def by_name(cls, _db, name):
-        """Turn the name of a Place into the Place itself.
-
-        :param name: A human-readable name of a place. If it makes
-        sense on its own, it will be interpreted as is. Otherwise, it
-        will be interpreted in the context of this registry's
-        `default` place.
-        """
-        everywhere = cls.everywhere(_db)
-        default = cls.default(_db)
-        parents = []
-        if default and default != everywhere:
-            parents.append(default)
-        parents.append(everywhere)
-        place = None
-
-        # Keep track of the first exception that was raised during
-        # this process. If we can't parse this Place name, we'll raise
-        # that exception because it's most likely to indicate the
-        # actual problem.
-        exception = None
-        for parent in parents:
-            try:
-                place = parent.lookup_inside(name)
-                if place is not None:
-                    exception = None
-                    break
-            except MultipleResultsFound, e:
-                if not exception:
-                    exception = e
-            except NoResultsFound, e:
-                if not exception:
-                    exception = e
-        if exception is not None:
-            raise exception
-        return place
-
-    @classmethod
     def larger_place_types(cls, type):
         """Return a list of place types known to be bigger than `type`.
 

--- a/model.py
+++ b/model.py
@@ -1065,31 +1065,27 @@ class Place(Base):
         return place
 
     @classmethod
-    def default_country(cls, _db):
-        """Return the default country for this library registry.
+    def default_nation(cls, _db):
+        """Return the default nation for this library registry.
 
-        If an incoming coverage area doesn't mention a country, we'll
-        assume it's within this country.
+        If an incoming coverage area doesn't mention a nation, we'll
+        assume it's within this nation.
 
-        :return: The default country, if one can be found. Otherwise, None.
+        :return: The default nation, if one can be found. Otherwise, None.
         """
-        default_country = None
-        country_name=ConfigurationSetting.sitewide(
-            _db, Configuration.DEFAULT_COUNTRY_NAME
+        default_nation = None
+        abbreviation=ConfigurationSetting.sitewide(
+            _db, Configuration.DEFAULT_NATION_ABBREVIATION
         ).value
-        everywhere = cls.everywhere(_db)
-        if country_name:
-            default_country = everywhere.lookup_inside(country_name)
-            if not default_country:
-                self.logging.error(
-                    "Could not look up default country %s", country_name
+        if abbreviation:
+            default_nation = get_one(
+                _db, Place, type=Place.NATION, abbreviated_name=abbreviation
+            )
+            if not default_nation:
+                logging.error(
+                    "Could not look up default nation %s", abbreviation
                 )
-            if default_country.type != Place.COUNTRY:
-                self.logging.error(
-                    "Default country %s is not a country!", country_name
-                )
-                default_country = None
-        return default_country
+        return default_nation
 
     @classmethod
     def by_name(cls, _db, name):

--- a/testing.py
+++ b/testing.py
@@ -446,8 +446,8 @@ class MockPlace(object):
     EVERYWHERE = MockEverywhere
 
     # Used within a test to provide a starting point for place
-    # names that don't mention a country.
-    _default_country = None
+    # names that don't mention a nation.
+    _default_nation = None
 
     by_name = dict()
 
@@ -456,8 +456,8 @@ class MockPlace(object):
         self.abbreviated_name = None
 
     @classmethod
-    def default_country(cls, _db):
-        return cls._default_country
+    def default_nation(cls, _db):
+        return cls._default_nation
 
     @classmethod
     def lookup_one_by_name(cls, _db, name, place_type):

--- a/testing.py
+++ b/testing.py
@@ -431,6 +431,10 @@ class MockRequestsResponse(object):
         return self.content.decode("utf8")
 
 
+class MockEverywhere(object):
+    abbreviated_name = None
+    external_name = "Everywhere"
+
 class MockPlace(object):
     """Used to test AuthenticationDocument.parse_coverage."""
 
@@ -439,12 +443,20 @@ class MockPlace(object):
 
     # Used to indicate coverage through the universe or through a
     # country.
-    EVERYWHERE = object()
+    EVERYWHERE = MockEverywhere
+
+    # Used within a test to provide a starting point for place
+    # names that don't mention a country.
+    _default_country = None
 
     by_name = dict()
 
     def __init__(self, inside=None):
         self.inside = inside or dict()
+
+    @classmethod
+    def default_country(cls, _db):
+        return cls._default_country
 
     @classmethod
     def lookup_one_by_name(cls, _db, name, place_type):
@@ -467,3 +479,4 @@ class MockPlace(object):
     @classmethod
     def everywhere(cls, _db):
         return cls.EVERYWHERE
+

--- a/testing.py
+++ b/testing.py
@@ -453,6 +453,7 @@ class MockPlace(object):
 
     def __init__(self, inside=None):
         self.inside = inside or dict()
+        self.abbreviated_name = None
 
     @classmethod
     def default_country(cls, _db):

--- a/testing.py
+++ b/testing.py
@@ -431,10 +431,6 @@ class MockRequestsResponse(object):
         return self.content.decode("utf8")
 
 
-class MockEverywhere(object):
-    abbreviated_name = None
-    external_name = "Everywhere"
-
 class MockPlace(object):
     """Used to test AuthenticationDocument.parse_coverage."""
 
@@ -443,7 +439,7 @@ class MockPlace(object):
 
     # Used to indicate coverage through the universe or through a
     # country.
-    EVERYWHERE = MockEverywhere
+    EVERYWHERE = object()
 
     # Used within a test to provide a starting point for place
     # names that don't mention a nation.

--- a/tests/test_authentication_document.py
+++ b/tests/test_authentication_document.py
@@ -24,7 +24,7 @@ from testing import MockPlace
 # Alias for a long class name
 AuthDoc = AuthenticationDocument
 
-class TestParseCoverage(object):
+class TestParseCoverage(DatabaseTest):
 
     EVERYWHERE = AuthenticationDocument.COVERAGE_EVERYWHERE
 
@@ -35,7 +35,7 @@ class TestParseCoverage(object):
         ambiguous place names, are as expected.
         """
         place_objs, unknown, ambiguous = AuthDoc.parse_coverage(
-            None, coverage_object, MockPlace
+            self._db, coverage_object, MockPlace
         )
         empty = defaultdict(list)
         expected_places = expected_places or []
@@ -141,6 +141,18 @@ class TestParseCoverage(object):
             expected_unknown={"US": ["Nowheresville"]}
         )
 
+    def test_unscoped_place(self):
+        # Test an authentication document that names a place without
+        # scoping it.
+        sf = MockPlace()
+        us = MockPlace(inside={"San Francisco": sf})
+        MockPlace.by_name["US"] = us
+        MockPlace._default = us
+
+        self.parse_places(
+            "San Francisco, US",
+            expected_places=[sf]
+        )
 
 class TestLinkExtractor(object):
     """Test the _extract_link helper method."""

--- a/tests/test_authentication_document.py
+++ b/tests/test_authentication_document.py
@@ -141,13 +141,13 @@ class TestParseCoverage(DatabaseTest):
             expected_unknown={"US": ["Nowheresville"]}
         )
 
-    def test_unscoped_place_is_in_default_country(self):
+    def test_unscoped_place_is_in_default_nation(self):
         # Test an authentication document that names places without
-        # saying which country they're in.
+        # saying which nation they're in.
         ca = MockPlace()
         ut = MockPlace()
 
-        # Without a default country on the server side, we can't make
+        # Without a default nation on the server side, we can't make
         # sense of these place names.
         self.parse_places("CA", expected_unknown={"??": "CA"})
 
@@ -159,14 +159,14 @@ class TestParseCoverage(DatabaseTest):
         us.abbreviated_name = "US"
         MockPlace.by_name["US"] = us
 
-        # With a default country in place, a bare string like "CA"
+        # With a default nation in place, a bare string like "CA"
         # is treated the same as a correctly formatted dictionary
         # like {"US": ["CA"]}
-        MockPlace._default_country = us
+        MockPlace._default_nation = us
         self.parse_places("CA", expected_places=[ca])
         self.parse_places(["CA", "UT"], expected_places=[ca, ut])
 
-        MockPlace._default_country = None
+        MockPlace._default_nation = None
 
 
 class TestLinkExtractor(object):

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -39,7 +39,7 @@ from . import (
 )
 
 
-class TestPlace(object):
+class TestPlace(DatabaseTest):
 
     def test_creation(self):
         # Create some US states represented by points.

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -109,6 +109,28 @@ class TestPlace(DatabaseTest):
         )
         eq_([alias], new_york.aliases)
 
+    def test_default_nation(self):
+        m = Place.default_nation
+
+        # We start out with no default nation.
+        eq_(None, m(self._db))
+
+        # The abbreviation of the default nation is stored in the
+        # DEFAULT_NATION_ABBREVIATION setting.
+        setting = ConfigurationSetting.sitewide(
+            self._db, Configuration.DEFAULT_NATION_ABBREVIATION
+        )
+        eq_(None, setting.value)
+
+        # Set the default nation to the United States.
+        setting.value = self.crude_us.abbreviated_name
+        eq_(self.crude_us, m(self._db))
+
+        # If there's no nation with this abbreviation,
+        # there is no default nation.
+        setting.value = "LL"
+        eq_(None, m(self._db))
+
     def test_overlaps_not_counting_border(self):
         """Test that overlaps_not_counting_border does not count places
         that share a border as intersecting, the way the PostGIS

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -39,7 +39,7 @@ from . import (
 )
 
 
-class TestPlace(DatabaseTest):
+class TestPlace(object):
 
     def test_creation(self):
         # Create some US states represented by points.


### PR DESCRIPTION
According to https://github.com/NYPL-Simplified/Simplified/wiki/Authentication-For-OPDS-Extensions#service_area, a place name like "San Francisco, CA" is invalid. But for the vast majority of libraries, that's the simplest way to represent the library's service area.

I made up that format and I can change the spec a bit (and probably will) to make things easier for people, but I can't change the fact that "San Francisco, CA" doesn't explicitly say which _country_ we're talking about. I don't want to add US-centric bits to the spec, but the vast majority of the people using NYPL's library registry will be in the US, and it would be nice to make things easier for them.

So, this branch allows a library registry to define a 'default nation'. If a coverage area comes in and it doesn't mention a nation, we try out the assumption that all those places are in the default nation _for that registry_. If that makes sense, everything's fine. Otherwise, we send an error, but we would have sent an error anyway.