### PR TITLE
Make it easy to interactively turn place names into GeoJSON objects

### DIFF
--- a/app.py
+++ b/app.py
@@ -98,6 +98,12 @@ def confirm_resource(resource_id, secret):
 def library(uuid):
     return app.library_registry.registry_controller.library(uuid)
 
+@app.route('/coverage')
+@returns_problem_detail
+def coverage():
+    return app.library_registry.coverage_controller.lookup()
+
+
 @app.route('/heartbeat')
 @returns_problem_detail
 def hearbeat():

--- a/controller.py
+++ b/controller.py
@@ -757,6 +757,10 @@ class CoverageController(object):
             self._db, coverage
         )
         document = Place.to_geojson(self._db, *places)
+
+        # Extend the GeoJSON with extra information about parts of the
+        # coverage document we found ambiguous or couldn't associate
+        # with a Place.
         if unknown:
             document['unknown'] = unknown
         if ambiguous:

--- a/model.py
+++ b/model.py
@@ -1140,6 +1140,16 @@ class Place(Base):
         )
         if place_type:
             qu = qu.filter(Place.type==place_type)
+        else:
+            # The place type "county" is excluded unless it was
+            # explicitly asked for (e.g. "Cook County"). This is to
+            # avoid ambiguity in the many cases when a state contains
+            # a county and a city with the same name. In all realistic
+            # cases, someone using "Foo" to talk about a library
+            # service area is referring to the city of Foo, not Foo
+            # County -- if they want Foo County they can say "Foo
+            # County".
+            qu = qu.filter(Place.type!=Place.COUNTY)
         return qu
 
     @classmethod

--- a/model.py
+++ b/model.py
@@ -1148,7 +1148,9 @@ class Place(Base):
 
     @classmethod
     def to_geojson(cls, _db, *places):
-        """Convert one or more Place objects to a GeoJSON document."""
+        """Convert one or more Place objects to a dictionary that will become
+        a GeoJSON document when converted to JSON.
+        """
         geojson = select(
             [func.ST_AsGeoJSON(Place.geometry)]
         ).where(
@@ -1158,11 +1160,13 @@ class Place(Base):
         if len(results) == 1:
             # There's only one item, and it is a valid
             # GeoJSON document on its own.
-            return results[0]
+            return json.loads(results[0])
 
+        # We have either more or less than one valid item.
+        # In either case, a GeometryCollection is appropriate.
         body = { "type": "GeometryCollection",
                  "geometries" : [json.loads(x) for x in results] }
-        return json.dumps(body)
+        return body
 
     @classmethod
     def name_parts(cls, name):

--- a/testing.py
+++ b/testing.py
@@ -202,6 +202,7 @@ class DatabaseTest(object):
             abbreviated_name=abbreviated_name, parent=parent,
         )
         place.geometry=geometry
+        self._db.commit()
         return place
 
     # Some useful Libraries.

--- a/testing.py
+++ b/testing.py
@@ -200,8 +200,8 @@ class DatabaseTest(object):
             self._db, Place, external_id=external_id,
             external_name=external_name, type=type,
             abbreviated_name=abbreviated_name, parent=parent,
-            geometry=geometry
         )
+        place.geometry=geometry
         return place
 
     # Some useful Libraries.

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -134,28 +134,16 @@ class TestPlace(DatabaseTest):
 
     def test_to_geojson(self):
 
-        def json_eq(g1, g2):
-            """Make sure two objects represent the same JSON object.
-
-            This mainly avoids confusions between a Python dictionary
-            and a JSON string representing the corresponding object.
-            """
-            if not isinstance(g1, dict):
-                g1 = json.loads(g1)
-            if not isinstance(g2, dict):
-                g2 = json.loads(g2)
-            return g1 == g2
-
         # If you ask for the GeoJSON of one place, that place is
         # returned as-is.
         zip1 = self.zip_10018
-        geojson = Place.to_geojson(self._db, zip1)
-        assert json_eq(geojson, self.zip_10018_geojson)
+        geojson = json.loads(Place.to_geojson(self._db, zip1))
+        eq_(geojson, json.loads(self.zip_10018_geojson))
 
         # If you ask for GeoJSON of several places, it's returned as a
         # GeometryCollection document.
         zip2 = self.zip_11212
-        geojson = json.loads(Place.to_geojson(self._db, zip1, zip2))
+        geojson = Place.to_geojson(self._db, zip1, zip2)
         eq_("GeometryCollection", geojson['type'])
 
         # There are two geometries in this document -- one for each
@@ -163,7 +151,7 @@ class TestPlace(DatabaseTest):
         geometries = geojson['geometries']
         eq_(2, len(geometries))
         for check in [self.zip_10018_geojson, self.zip_11212_geojson]:
-            assert any(json_eq(check, x) for x in geometries)
+            assert json.loads(check) in geojson['geometries']
 
     def test_overlaps_not_counting_border(self):
         """Test that overlaps_not_counting_border does not count places

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -137,7 +137,7 @@ class TestPlace(DatabaseTest):
         # If you ask for the GeoJSON of one place, that place is
         # returned as-is.
         zip1 = self.zip_10018
-        geojson = json.loads(Place.to_geojson(self._db, zip1))
+        geojson = Place.to_geojson(self._db, zip1)
         eq_(geojson, json.loads(self.zip_10018_geojson))
 
         # If you ask for GeoJSON of several places, it's returned as a
@@ -196,6 +196,25 @@ class TestPlace(DatabaseTest):
         eq_(["MA", "Boston"], m("Boston, MA,"))
         eq_(["USA", "Anytown"], m("Anytown, USA"))
         eq_(["US", "Ohio", "Lake County"], m("Lake County, Ohio, US"))
+
+    def test_lookup_by_name(self):
+
+        # There are two places in California called 'Santa Barbara': a
+        # city, and a county (which includes the city).
+        sb_city = self._place(external_name="Santa Barbara", type=Place.CITY)
+        sb_county = self._place(
+            external_name="Santa Barbara", type=Place.COUNTY
+        )
+
+        # If we look up "Santa Barbara" by name, we get the city.
+        m = Place.lookup_by_name
+        eq_([sb_city], m(self._db, "Santa Barbara").all())
+
+        # To get Santa Barbara County, we have to refer to
+        # "Santa Barbara County"
+        eq_(
+            [sb_county], m(self._db, "Santa Barbara County").all()
+        )
 
     def test_lookup_inside(self):
         us = self.crude_us

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -9,6 +9,7 @@ from sqlalchemy.exc import IntegrityError
 from sqlalchemy.orm.exc import MultipleResultsFound
 import base64
 import datetime
+import json
 import operator
 import random
 
@@ -130,6 +131,39 @@ class TestPlace(DatabaseTest):
         # there is no default nation.
         setting.value = "LL"
         eq_(None, m(self._db))
+
+    def test_to_geojson(self):
+
+        def json_eq(g1, g2):
+            """Make sure two objects represent the same JSON object.
+
+            This mainly avoids confusions between a Python dictionary
+            and a JSON string representing the corresponding object.
+            """
+            if not isinstance(g1, dict):
+                g1 = json.loads(g1)
+            if not isinstance(g2, dict):
+                g2 = json.loads(g2)
+            return g1 == g2
+
+        # If you ask for the GeoJSON of one place, that place is
+        # returned as-is.
+        zip1 = self.zip_10018
+        geojson = Place.to_geojson(self._db, zip1)
+        assert json_eq(geojson, self.zip_10018_geojson)
+
+        # If you ask for GeoJSON of several places, it's returned as a
+        # GeometryCollection document.
+        zip2 = self.zip_11212
+        geojson = json.loads(Place.to_geojson(self._db, zip1, zip2))
+        eq_("GeometryCollection", geojson['type'])
+
+        # There are two geometries in this document -- one for each
+        # Place we passed in.
+        geometries = geojson['geometries']
+        eq_(2, len(geometries))
+        for check in [self.zip_10018_geojson, self.zip_11212_geojson]:
+            assert any(json_eq(check, x) for x in geometries)
 
     def test_overlaps_not_counting_border(self):
         """Test that overlaps_not_counting_border does not count places


### PR DESCRIPTION
This branch adds a controller that takes place names (or, more generally, coverage areas as defined by https://github.com/NYPL-Simplified/Simplified/wiki/Authentication-For-OPDS-Extensions#service_area), parses them, and returns the corresponding GeoJSON objects. Eventually this can be used by the circulation manager to help admins graphically visualize their service areas. This will help them troubleshoot and it will also tell them when we can't identify a coverage area from a place name.

For now, I intend to use this myself when grandfathering in the coverage areas of the libraries already in the registry.

This is work towards https://jira.nypl.org/browse/SIMPLY-1044.