### PR TITLE
Advertise each library's focus and eligibility areas in its catalog entry

### DIFF
--- a/app.py
+++ b/app.py
@@ -18,6 +18,8 @@ from app_helpers import has_library_factory
 
 app = Flask(__name__)
 babel = Babel(app)
+
+# Create a has_library() annotator for this app.
 has_library = has_library_factory(app)
 
 testing = 'TESTING' in os.environ
@@ -99,16 +101,16 @@ def confirm_resource(resource_id, secret):
 def library():
     return app.library_registry.registry_controller.library()
 
-@app.route('/library/<uuid>/coverage')
+@app.route('/library/<uuid>/eligibility')
 @has_library
 @returns_problem_detail
-def library_coverage(uuid):
-    return app.library_registry.coverage_controller.coverage_for_library()
+def library_eligibility():
+    return app.library_registry.coverage_controller.eligibility_for_library()
 
 @app.route('/library/<uuid>/focus')
 @has_library
 @returns_problem_detail
-def library_focus(uuid):
+def library_focus():
     return app.library_registry.coverage_controller.focus_for_library()
 
 @app.route('/coverage')

--- a/app_helpers.py
+++ b/app_helpers.py
@@ -1,0 +1,25 @@
+from functools import wraps
+from util.problem_detail import ProblemDetail
+
+def has_library_factory(app):
+    """Create a decorator that extracts a library uuid from request arguments.
+    """
+    def factory(f):
+        @wraps(f)
+        def decorated(*args, **kwargs):
+            """A decorator that extracts a library UUID from request
+            arguments.
+            """
+            if 'uuid' in kwargs:
+                uuid = kwargs.pop("uuid")
+            else:
+                uuid = None
+            library = app.library_registry.registry_controller.library_for_request(
+                uuid
+            )
+            if isinstance(library, ProblemDetail):
+                return library.response
+            else:
+                return f(*args, **kwargs)
+        return decorated
+    return factory

--- a/controller.py
+++ b/controller.py
@@ -126,6 +126,8 @@ class BaseController(object):
 
     def library_for_request(self, uuid):
         """Look up the library the user is trying to access."""
+        if not uuid:
+            return LIBRARY_NOT_FOUND
         if not uuid.startswith("urn:uuid:"):
             uuid = "urn:uuid:" + uuid
         library = Library.for_urn(self._db, uuid)

--- a/controller.py
+++ b/controller.py
@@ -124,6 +124,10 @@ class LibraryRegistryAnnotator(Annotator):
 
 class BaseController(object):
 
+    def __init__(self, app):
+        self.app = app
+        self._db = self.app._db
+
     def library_for_request(self, uuid):
         """Look up the library the user is trying to access."""
         if not uuid:
@@ -148,8 +152,7 @@ class LibraryRegistryController(BaseController):
  </OpenSearchDescription>"""
 
     def __init__(self, app, emailer_class=Emailer):
-        self.app = app
-        self._db = self.app._db
+        super(LibraryRegistryController, self).__init__(app)
         self.annotator = LibraryRegistryAnnotator(app)
         self.log = self.app.log
         emailer = None
@@ -691,10 +694,6 @@ class ValidationController(BaseController):
 
     MESSAGE_TEMPLATE = "<html><head><title>%(message)s</title><body>%(message)s</body></html>"
 
-    def __init__(self, app):
-        self.app = app
-        self._db = self.app._db
-
     def html_response(self, status_code, message):
         """Return a human-readable message as a minimal HTML page.
 
@@ -755,10 +754,6 @@ class CoverageController(BaseController):
     """Converts coverage area descriptions to GeoJSON documents
     so they can be visualized.
     """
-
-    def __init__(self, app):
-        self.app = app
-        self._db = self.app._db
 
     def geojson_response(self, document):
         if isinstance(document, dict):

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -20,7 +20,7 @@ class TestAppHelpers(ControllerTest):
             return "Called with library %s" % flask.request.library.name
 
         def assert_not_found(uuid):
-            response = route_function()
+            response = route_function(uuid)
             eq_(LIBRARY_NOT_FOUND.response, response)
 
         assert_not_found(uuid=None)

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -1,0 +1,37 @@
+import flask
+from app_helpers import has_library_factory
+from nose.tools import (
+    eq_,
+    set_trace,
+)
+from problem_details import (
+    LIBRARY_NOT_FOUND
+)
+from test_controller import ControllerTest
+from testing import DatabaseTest
+
+class TestAppHelpers(ControllerTest):
+
+    def test_has_library(self):
+        has_library = has_library_factory(self.app)
+
+        @has_library
+        def route_function():
+            return "Called with library %s" % flask.request.library.name
+
+        def assert_not_found(uuid):
+            response = route_function()
+            eq_(LIBRARY_NOT_FOUND.response, response)
+
+        assert_not_found(uuid=None)
+        assert_not_found(uuid="no such library")
+        library = self.nypl
+
+        urns = [
+            library.internal_urn,
+            library.internal_urn[len("urn:uuid:"):]
+        ]
+        for urn in urns:
+            with self.app.test_request_context():
+                response = route_function(uuid=urn)
+                eq_("Called with library NYPL", response)


### PR DESCRIPTION
This branch adds links to a library's OPDS catalog which let a client grab GeoJSON representations of its focus area and eligibility area. This can be used either by a circulation manager's admin interface ("did I get the service area right?") or by a mobile or web client ("is this my local library?")

I added two controllers which take a library UUID as their input, so rather than copy the code in the existing `library` controller (for looking up a specific library's catalog entry), I wrote the equivalent of the `has_library` function we use in the circulation manager.

Unlike that `has_library`, though, this one is testable, because I created a factory function which takes an app server as an argument and generates a `has_library` implementation for that app server.