### PR TITLE
Handle the case where we know a library's service areas and the library doesn't

### DIFF
--- a/authentication_document.py
+++ b/authentication_document.py
@@ -357,6 +357,14 @@ class AuthenticationDocument(object):
         # no input was specified.
         empty = [[],{},{}]
 
+        if focus_area == empty and service_area == empty:
+            # A library can't lose its entire coverage area -- it's
+            # more likely that the coverage area was grandfathered in
+            # and it just isn't set on the remote side.
+            #
+            # Do nothing.
+            return
+
         if (focus_area == empty and service_area != empty
             or service_area == focus_area):
             # Service area and focus area are the same, either because

--- a/tests/test_authentication_document.py
+++ b/tests/test_authentication_document.py
@@ -369,7 +369,7 @@ class TestLinkExtractor(object):
 class TestUpdateServiceAreas(DatabaseTest):
 
     def test_set_service_areas(self):
-        """Test the method that replaces a Library's ServiceAreas."""
+        # Test the method that replaces a Library's ServiceAreas.
         m = AuthenticationDocument.set_service_areas
 
         library = self._library()
@@ -385,9 +385,9 @@ class TestUpdateServiceAreas(DatabaseTest):
                     if x.type==ServiceArea.FOCUS]
 
         # Try a successful case.
-        service_area = [[p1], {}, {}]
-        focus_area = [[p2], {}, {}]
-        m(library, service_area, focus_area)
+        p1_only = [[p1], {}, {}]
+        p2_only = [[p2], {}, {}]
+        m(library, p1_only, p2_only)
         eq_([p1], eligibility_areas())
         eq_([p2], focus_areas())
 
@@ -397,11 +397,14 @@ class TestUpdateServiceAreas(DatabaseTest):
         eq_([p1], eligibility_areas())
         eq_([p2], focus_areas())
 
-        # If you pass in one empty input, both service and focus
-        # area are set to the same value.
-        set_trace()
-        m(library, focus_area, empty)
-        eq_([p2], eligibility_areas())
+        # If you pass only one value, the focus area is set to that
+        # value and the eligibility area is cleared out.
+        m(library, p1_only, empty)
+        eq_([], eligibility_areas())
+        eq_([p1], focus_areas())
+
+        m(library, empty, p2_only)
+        eq_([], eligibility_areas())
         eq_([p2], focus_areas())
         
 
@@ -558,9 +561,8 @@ class TestUpdateServiceAreas(DatabaseTest):
         self._db.commit()
         eq_(None, problem)
 
-        [area] = library.eligibility_areas
-        [area2] = library.focus_areas
-        eq_(area, area2)
+        # Only the focus area is set.
+        [area] = library.service_areas
         eq_(Place.EVERYWHERE, area.place.type)
         eq_(ServiceArea.FOCUS, area.type)
 

--- a/tests/test_authentication_document.py
+++ b/tests/test_authentication_document.py
@@ -406,7 +406,7 @@ class TestUpdateServiceAreas(DatabaseTest):
         m(library, empty, p2_only)
         eq_([], eligibility_areas())
         eq_([p2], focus_areas())
-        
+
 
     def test_known_place_becomes_servicearea(self):
         """Test the helper method in a successful case."""
@@ -546,7 +546,7 @@ class TestUpdateServiceAreas(DatabaseTest):
         eq_(ServiceArea.FOCUS, area.type)
 
 
-    def test_service_area_and_focus_area_identical(self):
+    def test_service_area_registered_as_focus_area_if_identical_to_focus_area(self):
         library = self._library()
 
         # Create an authentication document that defines service_area
@@ -561,7 +561,8 @@ class TestUpdateServiceAreas(DatabaseTest):
         self._db.commit()
         eq_(None, problem)
 
-        # Only the focus area is set.
+        # Since focus area and eligibility area are the same, only the
+        # focus area was registered.
         [area] = library.service_areas
         eq_(Place.EVERYWHERE, area.place.type)
         eq_(ServiceArea.FOCUS, area.type)


### PR DESCRIPTION
We're going to go through a period where most library service areas are grandfathered in on the library registry side. While this is happening (and even afterwards) we don't want the library registration process to remove coverage areas just because the library's authentication document doesn't provide anything. The lack of information signifies a lack of knowledge on the circ manager's part, not an assertion that a library has no coverage area.

This branch changes `AuthenticationDocument.set_service_areas` to do nothing when no input is provided. I also add a little general coverage of that method, which up to this point has only been tested indirectly.