### PR TITLE
It's now possible to simulate a request from anywhere by passing in latitude/longitude coordinates.

### DIFF
--- a/app.py
+++ b/app.py
@@ -11,16 +11,19 @@ from config import Configuration
 from controller import LibraryRegistry
 from log import LogConfiguration
 from model import SessionManager, ConfigurationSetting
-from util.flask_util import originating_ip
 from util.app_server import returns_problem_detail
-from app_helpers import has_library_factory
+from app_helpers import (
+    has_library_factory,
+    uses_location_factory,
+)
 
 
 app = Flask(__name__)
 babel = Babel(app)
 
-# Create a has_library() annotator for this app.
+# Create annotators for this app.
 has_library = has_library_factory(app)
+uses_location = uses_location_factory(app)
 
 testing = 'TESTING' in os.environ
 db_url = Configuration.database_url(testing)
@@ -56,17 +59,17 @@ def shutdown_session(exception):
             app.library_registry._db.commit()
 
 @app.route('/')
+@uses_location
 @returns_problem_detail
-def nearby():
-    return app.library_registry.registry_controller.nearby(
-        originating_ip()
-    )
+def nearby(_location):
+    return app.library_registry.registry_controller.nearby(_location)
 
 @app.route('/qa')
+@uses_location
 @returns_problem_detail
-def nearby_qa():
+def nearby_qa(_location):
     return app.library_registry.registry_controller.nearby(
-        originating_ip(), live=False
+        _location, live=False
     )
 
 @app.route("/register", methods=["GET","POST"])
@@ -75,17 +78,17 @@ def register():
     return app.library_registry.registry_controller.register()
 
 @app.route('/search')
+@uses_location
 @returns_problem_detail
-def search():
-    return app.library_registry.registry_controller.search(
-        originating_ip()
-    )
+def search(_location):
+    return app.library_registry.registry_controller.search(_location)
 
 @app.route('/qa/search')
+@uses_location
 @returns_problem_detail
-def search_qa():
+def search_qa(_location):
     return app.library_registry.registry_controller.search(
-        originating_ip(), live=False
+        _location, live=False
     )
 
 @app.route('/confirm/<int:resource_id>/<secret>')

--- a/app_helpers.py
+++ b/app_helpers.py
@@ -36,7 +36,6 @@ def uses_location_factory(app):
         def decorated(*args, **kwargs):
             """A decorator that guesses at a location for the client."""
             location = flask.request.args.get("_location")
-            set_trace()
             if location:
                 location = GeometryUtility.point_from_string(location)
             if not location:

--- a/app_helpers.py
+++ b/app_helpers.py
@@ -1,5 +1,9 @@
+import flask
 from functools import wraps
+from nose.tools import set_trace
+from util import GeometryUtility
 from util.problem_detail import ProblemDetail
+from util.flask_util import originating_ip
 
 def has_library_factory(app):
     """Create a decorator that extracts a library uuid from request arguments.
@@ -21,5 +25,23 @@ def has_library_factory(app):
                 return library.response
             else:
                 return f(*args, **kwargs)
+        return decorated
+    return factory
+
+def uses_location_factory(app):
+    """Create a decorator that guesses at a location for the client.
+    """
+    def factory(f):
+        @wraps(f)
+        def decorated(*args, **kwargs):
+            """A decorator that guesses at a location for the client."""
+            location = flask.request.args.get("_location")
+            set_trace()
+            if location:
+                location = GeometryUtility.point_from_string(location)
+            if not location:
+                ip = originating_ip()
+                location = GeometryUtility.point_from_ip(ip)
+            return f(*args,  _location=location, **kwargs)
         return decorated
     return factory

--- a/controller.py
+++ b/controller.py
@@ -165,14 +165,8 @@ class LibraryRegistryController(BaseController):
             )
         self.emailer = emailer
 
-    def point_from_ip(self, ip_address):
-        if not ip_address:
-            return None
-        return GeometryUtility.point_from_ip(ip_address)
-
-    def nearby(self, ip_address, live=True):
-        point = self.point_from_ip(ip_address)
-        qu = Library.nearby(self._db, point, production=live)
+    def nearby(self, location, live=True):
+        qu = Library.nearby(self._db, location, production=live)
         qu = qu.limit(5)
         if live:
             nearby_controller = 'nearby'
@@ -185,8 +179,7 @@ class LibraryRegistryController(BaseController):
         )
         return catalog_response(catalog)
 
-    def search(self, ip_address=None, live=True):
-        point = self.point_from_ip(ip_address)
+    def search(self, location, live=True):
         query = flask.request.args.get('q')
         if live:
             search_controller = 'search'
@@ -195,7 +188,7 @@ class LibraryRegistryController(BaseController):
         if query:
             # Run the query and send the results.
             results = Library.search(
-                self._db, point, query, production=live
+                self._db, location, query, production=live
             )
 
             this_url = self.app.url_for(

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -1,5 +1,8 @@
 import flask
-from app_helpers import has_library_factory
+from app_helpers import (
+    has_library_factory,
+    uses_location_factory,
+)
 from nose.tools import (
     eq_,
     set_trace,
@@ -35,3 +38,18 @@ class TestAppHelpers(ControllerTest):
             with self.app.test_request_context():
                 response = route_function(uuid=urn)
                 eq_("Called with library NYPL", response)
+
+    def test_uses_location(self):
+        uses_location = uses_location_factory(self.app)
+
+        @uses_location
+        def route_function(_location):
+            return "Called with location %s" % _location
+
+        with self.app.test_request_context():
+            eq_("Called with location None", route_function())
+
+        with self.app.test_request_context("/?_location=-10,10"):
+            eq_("Called with location SRID=4326;POINT (10.0 -10.0)",
+                route_function())
+

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -14,3 +14,17 @@ class TestGeometryUtility(object):
         point = GeometryUtility.point_from_ip("65.88.88.124")
         eq_('SRID=4326;POINT (-73.9813 40.7769)', point)
 
+    def test_point_from_string(self):
+        m = GeometryUtility.point_from_string
+
+        # Lots of strings don't map to latitude/longitude.
+        eq_(None, m(None))
+        eq_(None, m("No comma"))
+        eq_(None, m("Not a number, -71"))
+        eq_(None, m("-400,1"))
+        eq_(None, m("1,400"))
+
+        # Here are some strings that do.
+        for coords in ("40.7769, -73.9813", "40.7769,-73.9813"):
+            eq_('SRID=4326;POINT (-73.9813 40.7769)', m(coords))
+

--- a/util/__init__.py
+++ b/util/__init__.py
@@ -16,10 +16,30 @@ class GeometryUtility(object):
 
     @classmethod
     def point_from_ip(cls, ip_address):
+        if not ip_address:
+            return None
         match = geolite2.lookup(ip_address)
         if match is None:
             return None
         return cls.point(*match.location)        
+
+    @classmethod
+    def point_from_string(cls, s):
+        """Parse a string representing latitude and longitude
+        into a Geometry object.
+        """
+        if not s or not ',' in s:
+            return None
+        parts = []
+        for i in s.split(',', 1):
+            try:
+                i = float(i.strip())
+            except ValueError, e:
+                return None
+            parts.append(i)
+        if any(abs(x) > 180 for x in parts):
+            return None
+        return cls.point(*parts)
     
     @classmethod
     def point(cls, latitude, longitude):


### PR DESCRIPTION
This branch defines a new annotator called `uses_location`. A routing function annotated with `uses_location` should take an argument called `_location`. The app server will make its best guess at the user's location and pass in that Point as `_location`.

This has two benefits:

* You can put `_location=latitude,longitude` in any request to simulate a request from that point. If incoming `_location` is specified in the request, `uses_location` will use that point instead of trying to figure it out from the IP address. This lets us simulate a request from anywhere when testing.
* Location-aware controllers now take a Point as input rather than an IP address, making them easier to test.