### PR TITLE
Only reset the shared secret if the library asked for it to be reset.

### DIFF
--- a/tests/test_controller.py
+++ b/tests/test_controller.py
@@ -1136,7 +1136,7 @@ class TestLibraryRegistryController(ControllerTest):
             ("contact", "mailto:me@library.org")
         ])
         form_args_with_reset = ImmutableMultiDict(
-            form_args_no_reset + [
+            form_args_no_reset.items() + [
                 ("reset_shared_secret", "y")
             ]
         )
@@ -1171,15 +1171,19 @@ class TestLibraryRegistryController(ControllerTest):
             with self.app.test_request_context("/", headers={"Authorization": "Bearer %s" % secret}):
                 flask.request.form = form
 
-            key = RSA.generate(1024)
-            auth_document = self._auth_document(key)
-            self.http_client.queue_response(200, content=json.dumps(auth_document))
-            self.queue_opds_success()
+                key = RSA.generate(1024)
+                auth_document = self._auth_document(key)
+                self.http_client.queue_response(
+                    200, content=json.dumps(auth_document)
+                )
+                self.queue_opds_success()
 
-            response = self.controller.register(do_get=self.http_client.do_get)
+                response = self.controller.register(
+                    do_get=self.http_client.do_get
+                )
 
-            eq_(200, response.status_code)
-            eq_(old_secret, library.shared_secret)
+                eq_(200, response.status_code)
+                eq_(old_secret, library.shared_secret)
 
     def test_register_with_secret_changes_authentication_url(self):
         # This Library was created previously with a certain shared

--- a/util/http.py
+++ b/util/http.py
@@ -1,8 +1,12 @@
+import logging
 from nose.tools import set_trace
 import requests
 import urlparse
 from flask_babel import lazy_gettext as _
-from problem_detail import ProblemDetail as pd
+from problem_detail import (
+    ProblemDetail as pd,
+    JSON_MEDIA_TYPE as PROBLEM_DETAIL_JSON_MEDIA_TYPE,
+)
 
 INTEGRATION_ERROR = pd(
       "http://librarysimplified.org/terms/problem/remote-integration-failed",
@@ -11,29 +15,58 @@ INTEGRATION_ERROR = pd(
       _("A third-party service has failed."),
 )
 
-class RemoteIntegrationException(Exception):
+class IntegrationException(Exception):
+    """An exception that happens when the site's connection to a
+    third-party service is broken.
 
-    """An exception that happens when communicating with a third-party
-    service.
+    This may be because communication failed
+    (RemoteIntegrationException), or because local configuration is
+    missing or obviously wrong (CannotLoadConfiguration).
     """
+
+    def __init__(self, message, debug_message=None):
+        """Constructor.
+
+        :param message: The normal message passed to any Exception
+        constructor.
+
+        :param debug_message: An extra human-readable explanation of the
+        problem, shown to admins but not to patrons. This may include
+        instructions on what bits of the integration configuration might need
+        to be changed.
+
+        For example, an API key might be wrong, or the API key might
+        be correct but the API provider might not have granted that
+        key enough permissions.
+        """
+        super(IntegrationException, self).__init__(message)
+        self.debug_message = debug_message
+
+
+class RemoteIntegrationException(IntegrationException):
+    """An exception that happens when we try and fail to communicate
+    with a third-party service over HTTP.
+    """
+
     title = _("Failure contacting external service")
     detail = _("The server tried to access %(service)s but the third-party service experienced an error.")
     internal_message = "Error accessing %s: %s"
 
     def __init__(self, url_or_service, message, debug_message=None):
         """Indicate that a remote integration has failed.
-        
+
         `param url_or_service` The name of the service that failed
            (e.g. "Overdrive"), or the specific URL that had the problem.
         """
-        super(RemoteIntegrationException, self).__init__(message)
         if (url_or_service and
             any(url_or_service.startswith(x) for x in ('http:', 'https:'))):
             self.url = url_or_service
             self.service = urlparse.urlparse(url_or_service).netloc
         else:
             self.url = self.service = url_or_service
-        self.debug_message = debug_message
+        if not debug_message:
+            debug_message = self.internal_message % (self.url, message)
+        super(RemoteIntegrationException, self).__init__(message, debug_message)
 
     def __str__(self):
         return self.internal_message % (self.url, self.message)
@@ -50,7 +83,7 @@ class RemoteIntegrationException(Exception):
 
     def as_problem_detail_document(self, debug):
         return INTEGRATION_ERROR.detailed(
-            detail=self.document_detail(debug), title=self.title, 
+            detail=self.document_detail(debug), title=self.title,
             debug_message=self.document_debug_message(debug)
         )
 
@@ -64,7 +97,7 @@ class BadResponseException(RemoteIntegrationException):
 
     def __init__(self, url_or_service, message, debug_message=None, status_code=None):
         """Indicate that a remote integration has failed.
-        
+
         `param url_or_service` The name of the service that failed
            (e.g. "Overdrive"), or the specific URL that had the problem.
         """
@@ -93,8 +126,8 @@ class BadResponseException(RemoteIntegrationException):
             status_code = response.status_code
             content = response.content
         return BadResponseException(
-            url, message, 
-            status_code=status_code, 
+            url, message,
+            status_code=status_code,
             debug_message="Status code: %s\nContent: %s" % (
                 status_code,
                 content,
@@ -147,26 +180,39 @@ class HTTP(object):
         return cls.request_with_timeout("POST", url, *args, **kwargs)
 
     @classmethod
+    def put_with_timeout(cls, url, payload, *args, **kwargs):
+        """Make a PUT request with timeout handling."""
+        kwargs['data'] = payload
+        return cls.request_with_timeout("PUT", url, *args, **kwargs)
+
+    @classmethod
     def request_with_timeout(cls, http_method, url, *args, **kwargs):
         """Call requests.request and turn a timeout into a RequestTimedOut
         exception.
         """
         return cls._request_with_timeout(
-            url, requests.request, http_method, url, *args, **kwargs
+            url, requests.request, http_method, *args, **kwargs
         )
 
     @classmethod
-    def _request_with_timeout(cls, url, m, *args, **kwargs):
+    def _request_with_timeout(cls, url, make_request_with, *args, **kwargs):
         """Call some kind of method and turn a timeout into a RequestTimedOut
         exception.
+
         The core of `request_with_timeout` made easy to test.
+
+        :param url: Make the request to this URL.
+        :param make_request_with: A function that actually makes the
+            HTTP request.
+        :param args: Positional arguments for the request function.
+        :param kwargs: Keyword arguments for the request function.
         """
-        allowed_response_codes = kwargs.get('allowed_response_codes')
-        if 'allowed_response_codes' in kwargs:
-            del kwargs['allowed_response_codes']
-        disallowed_response_codes = kwargs.get('disallowed_response_codes')
-        if 'disallowed_response_codes' in kwargs:
-            del kwargs['disallowed_response_codes']
+        process_response_with = kwargs.pop(
+            'process_response_with', cls._process_response
+        )
+        allowed_response_codes = kwargs.pop('allowed_response_codes', [])
+        disallowed_response_codes = kwargs.pop('disallowed_response_codes', [])
+        verbose = kwargs.pop('verbose', False)
 
         if not 'timeout' in kwargs:
             kwargs['timeout'] = 20
@@ -187,9 +233,24 @@ class HTTP(object):
             kwargs['headers'] = new_headers
 
         try:
-            response = m(*args, **kwargs)
+            if verbose:
+                logging.info("Sending %s request to %s: kwargs %r",
+                             http_method, url, kwargs)
+            if len(args) == 1:
+                # requests.request takes two positional arguments,
+                # an HTTP method and a URL. In most cases, the URL
+                # gets added on here. But if you do pass in both
+                # arguments, it will still work.
+                args = args + (url,)
+            response = make_request_with(*args, **kwargs)
+            if verbose:
+                logging.info(
+                    "Response from %s: %s %r %r",
+                    url, response.status_code, response.headers,
+                    response.content
+                )
         except requests.exceptions.Timeout, e:
-            # Wrap the requests-specific Timeout exception 
+            # Wrap the requests-specific Timeout exception
             # in a generic RequestTimedOut exception.
             raise RequestTimedOut(url, e.message)
         except requests.exceptions.RequestException, e:
@@ -197,7 +258,7 @@ class HTTP(object):
             # a generic RequestNetworkException.
             raise RequestNetworkException(url, e.message)
 
-        return cls._process_response(
+        return process_response_with(
             url, response, allowed_response_codes, disallowed_response_codes
         )
 
@@ -207,26 +268,29 @@ class HTTP(object):
         """Raise a RequestNetworkException if the response code indicates a
         server-side failure, or behavior so unpredictable that we can't
         continue.
-        :param allowed_response_codes If passed, then only the responses with 
-            http status codes in this list are processed.  The rest generate  
+
+        :param allowed_response_codes If passed, then only the responses with
+            http status codes in this list are processed.  The rest generate
             BadResponseExceptions.
-        :param disallowed_response_codes The values passed are added to 5xx, as 
+        :param disallowed_response_codes The values passed are added to 5xx, as
             http status codes that would generate BadResponseExceptions.
         """
         if allowed_response_codes:
             allowed_response_codes = map(str, allowed_response_codes)
-            status_code_not_in_allowed = "Got status code %%s from external server, but can only continue on: %s." % ", ".join(sorted(allowed_response_codes))
+            status_code_not_in_allowed = "Got status code %%s from external server, but can only continue on: %s." % (
+                ", ".join(sorted(allowed_response_codes)),
+            )
         if disallowed_response_codes:
             disallowed_response_codes = map(str, disallowed_response_codes)
         else:
             disallowed_response_codes = []
 
         code = response.status_code
-        series = "%sxx" % (code / 100)
+        series = cls.series(code)
         code = str(code)
 
         if allowed_response_codes and (
-                code in allowed_response_codes 
+                code in allowed_response_codes
                 or series in allowed_response_codes
         ):
             # The code or series has been explicitly allowed. Allow
@@ -241,7 +305,7 @@ class HTTP(object):
             # an exception.
             error_message = BadResponseException.BAD_STATUS_CODE_MESSAGE
         elif (allowed_response_codes and not (
-                code in allowed_response_codes 
+                code in allowed_response_codes
                 or series in allowed_response_codes
         )):
             error_message = status_code_not_in_allowed
@@ -249,8 +313,90 @@ class HTTP(object):
         if error_message:
             raise BadResponseException(
                 url,
-                error_message % code, 
+                error_message % code,
                 status_code=code,
                 debug_message="Response content: %s" % response.content
             )
         return response
+
+    @classmethod
+    def series(cls, status_code):
+        """Return the HTTP series for the given status code."""
+        return "%sxx" % (status_code / 100)
+
+    @classmethod
+    def debuggable_get(cls, url, **kwargs):
+        """Make a GET request that returns a detailed problem
+        detail document on error.
+        """
+        return cls.debuggable_request("GET", url, **kwargs)
+
+    @classmethod
+    def debuggable_post(cls, url, payload, **kwargs):
+        """Make a POST request that returns a detailed problem
+        detail document on error.
+        """
+        kwargs['data'] = payload
+        return cls.debuggable_request("POST", url, **kwargs)
+
+    @classmethod
+    def debuggable_request(cls, http_method, url, make_request_with=None,
+                           **kwargs):
+        """Make a request that returns a detailed problem detail document on
+        error, rather than a generic "an integration error occured"
+        message.
+
+        :param http_method: HTTP method to use when making the request.
+        :param url: Make the request to this URL.
+        :param make_request_with: A function that actually makes the
+            HTTP request.
+        :param kwargs: Keyword arguments for the make_request_with
+            function.
+        """
+        logging.info("Making debuggable %s request to %s: kwargs %r",
+                     http_method, url, kwargs)
+        make_request_with = make_request_with or requests.request
+        return cls._request_with_timeout(
+            url, make_request_with, http_method,
+            process_response_with=cls.process_debuggable_response,
+            **kwargs
+        )
+
+    @classmethod
+    def process_debuggable_response(cls, url, response, disallowed_response_codes=None, allowed_response_codes=None):
+        """If there was a problem with an integration request,
+        return an appropriate ProblemDetail. Otherwise, return the
+        response to the original request.
+
+        :param response: A Response object from the requests library.
+        """
+
+        allowed_response_codes = allowed_response_codes or ['2xx', '3xx']
+        allowed_response_codes = map(str, allowed_response_codes)
+        code = response.status_code
+        series = cls.series(code)
+        if str(code) in allowed_response_codes or series in allowed_response_codes:
+            # Whether or not it looks like there's been a problem,
+            # we've been told to let this response code through.
+            return response
+
+        content_type = response.headers.get('Content-Type')
+        if content_type == PROBLEM_DETAIL_JSON_MEDIA_TYPE:
+            # The server returned a problem detail document. Wrap it
+            # in a new document that represents the integration
+            # failure.
+            problem = INTEGRATION_ERROR.detailed(
+                _('Remote service returned a problem detail document: %r') % (
+                    response.content
+                )
+            )
+            problem.debug_message = response.content
+            return problem
+        # There's been a problem. Return the message we got from the
+        # server, verbatim.
+        return INTEGRATION_ERROR.detailed(
+            _("%s response from integration server: %r") % (
+                response.status_code,
+                response.content,
+            )
+        )


### PR DESCRIPTION
This branch resolves https://jira.nypl.org/browse/SIMPLY-1395.

The changes to http.py are caused by simply copying in a new copy of https://github.com/NYPL-Simplified/server_core/blob/master/util/http.py. I used this to add some debugging to make it easier to go back and forth with people who are having trouble completing their registrations.