### PR TITLE
Return library details on validate email

### DIFF
--- a/controller.py
+++ b/controller.py
@@ -302,7 +302,7 @@ class LibraryRegistryController(BaseController):
         validation.restart()
         validation.mark_as_successful()
 
-        return Response(unicode(library.internal_urn), 200)
+        return self.library_details(uuid)
 
     def edit_registration(self):
         # Edit a specific library's registry_stage and library_stage based on information which an admin has submitted in the interface.

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   "author": "NYPL",
   "license": "Apache-2.0",
   "dependencies": {
-    "simplified-registry-admin": "1.0.2"
+    "simplified-registry-admin": "1.0.3"
   },
   "homepage": "https://github.com/NYPL-Simplified/library_registry#readme"
 }

--- a/tests/test_controller.py
+++ b/tests/test_controller.py
@@ -395,9 +395,7 @@ class TestLibraryRegistryController(ControllerTest):
             flask.request.form = MultiDict([
                 ("uuid", uuid),
             ])
-            response = self.controller.validate_email()
-        eq_(response.response, [nypl.internal_urn])
-        eq_(response.status_code, 200)
+            self.controller.validate_email()
 
         validation = nypl.hyperlinks[0].resource.validation
         assert isinstance(validation, Validation)


### PR DESCRIPTION
This change is just to improve the performance on the front end; it makes the library info update itself in a more visually smooth way after an email address is validated.  Goes with https://github.com/NYPL-Simplified/registry_admin/pull/9, which resolves https://jira.nypl.org/browse/SIMPLY-1725.