### PR TITLE
Store the ToS link as a hyperlink, not as the actual text of the ToS.

### DIFF
--- a/config.py
+++ b/config.py
@@ -39,8 +39,9 @@ class Configuration(object):
     ADOBE_VENDOR_ID_NODE_VALUE = "node_value"
     ADOBE_VENDOR_ID_DELEGATE_URL = "delegate_url"
 
-    # The text to which users must agree to register a library.
-    REGISTRATION_TERMS_OF_SERVICE_TEXT = "registration_terms_of_service_text"
+    # The URL to the document containing the terms of servier for
+    # library registration
+    REGISTRATION_TERMS_OF_SERVICE_URL = "registration_terms_of_service_url"
 
     # Email sent by the library registry will be 'from' this address,
     # and receipients will be invited to contact this address if they

--- a/controller.py
+++ b/controller.py
@@ -401,19 +401,17 @@ class LibraryRegistryController(BaseController):
         """Serve a document that describes the registration process,
         notably the terms of service for that process.
 
-        The terms of service are included inline as a data: URI,
-        to avoid the need to fetch them in a separate request.
+        The terms of service are hosted elsewhere; we only know the
+        URL of the page they're stored.
         """
         document = dict()
-        terms_of_service = ConfigurationSetting.sitewide(
-            self._db, Configuration.REGISTRATION_TERMS_OF_SERVICE_TEXT
+        terms_of_service_url = ConfigurationSetting.sitewide(
+            self._db, Configuration.REGISTRATION_TERMS_OF_SERVICE_URL
         ).value
-        if terms_of_service:
-            terms_of_service = base64.encodestring(terms_of_service)
-            terms_of_service_uri = "data:text/html;%s" % terms_of_service
+        if terms_of_service_url:
             OPDSCatalog.add_link_to_catalog(
                 document, rel="terms-of-service",
-                href=terms_of_service_uri
+                href=terms_of_service_url
             )
         return document
 

--- a/tests/test_controller.py
+++ b/tests/test_controller.py
@@ -724,21 +724,20 @@ class TestLibraryRegistryController(ControllerTest):
             eq_('{}', response.data)
 
         # Set some terms of service.
-        tos = "Some terms"
+        tos = "http://terms.com/service.html"
         ConfigurationSetting.sitewide(
-            self._db, Configuration.REGISTRATION_TERMS_OF_SERVICE_TEXT
+            self._db, Configuration.REGISTRATION_TERMS_OF_SERVICE_URL
         ).value = tos
 
-        # Now the document 'links' to the terms of service via a data:
-        # URI.
+        # Now the document contains one link, to the terms of service
+        # document.
         with self.app.test_request_context("/", method="GET"):
             response = self.controller.register()
             eq_(200, response.status_code)
             data = json.loads(response.data)
             [link] = data['links']
             eq_("terms-of-service", link["rel"])
-            eq_("data:text/html;%s" % base64.encodestring(tos),
-                link['href'])
+            eq_(tos, link['href'])
 
     def test_register_fails_when_no_auth_document_url_provided(self):
         """Without the URL to an Authentication For OPDS document,


### PR DESCRIPTION
This fixes https://jira.nypl.org/browse/SIMPLY-1744.

Since the ToS hasn't been deployed or finalized yet, there's no migration. But it's now way too big to include inline.

The circ manager doesn't yet pick up this data (that's https://jira.nypl.org/browse/SIMPLY-467), so there's no circ change either.