### PR TITLE
Endpoint to return all libraries not in a cancelled stage in OPDS format

### DIFF
--- a/app.py
+++ b/app.py
@@ -105,6 +105,11 @@ def confirm_resource(resource_id, secret):
         resource_id, secret
     )
 
+@app.route('/libraries')
+@returns_problem_detail
+def libraries_opds():
+    return app.library_registry.registry_controller.libraries_opds()
+
 @app.route('/admin/log_in', methods=["POST"])
 @returns_problem_detail
 def log_in():
@@ -119,11 +124,6 @@ def log_out():
 @returns_json_or_response_or_problem_detail
 def libraries():
     return app.library_registry.registry_controller.libraries()
-
-@app.route('/admin/libraries_opds')
-@returns_problem_detail
-def libraries_opds():
-    return app.library_registry.registry_controller.libraries_opds()
 
 @app.route('/admin/libraries/<uuid>')
 @returns_json_or_response_or_problem_detail

--- a/app.py
+++ b/app.py
@@ -120,6 +120,11 @@ def log_out():
 def libraries():
     return app.library_registry.registry_controller.libraries()
 
+@app.route('/admin/libraries_opds')
+@returns_problem_detail
+def libraries_opds():
+    return app.library_registry.registry_controller.libraries_opds()
+
 @app.route('/admin/libraries/<uuid>')
 @returns_json_or_response_or_problem_detail
 def library_details(uuid):

--- a/controller.py
+++ b/controller.py
@@ -241,6 +241,21 @@ class LibraryRegistryController(BaseController):
             libraries += [self.library_details(uuid, library)]
         return dict(libraries=libraries)
 
+    def libraries_opds(self):
+        """Return all the libraries in OPDS format"""
+
+        qu = self._db.query(Library)
+        # We want to restrict libraries that are either in production
+        # or in the testing stage but not cancelled.
+        all_libraries = qu.filter(Library._feed_restriction(production=False)).order_by(Library.name)
+
+        url = self.app.url_for("libraries_opds")
+        catalog = OPDSCatalog(
+            self._db, 'Libraries', url, all_libraries,
+            annotator=self.annotator, live=True
+        )
+        return catalog_response(catalog)
+
     def library_details(self, uuid, library=None):
         # Return complete information about one specific library.
         if not library:

--- a/tests/test_controller.py
+++ b/tests/test_controller.py
@@ -309,10 +309,9 @@ class TestLibraryRegistryController(ControllerTest):
         libraries = response.get("libraries")
 
         # There are currently four libraries,
-        # These libraries have been added from the previous test.
         eq_(len(libraries), 4)
 
-        with self.app.test_request_context("/libraries_opds"):
+        with self.app.test_request_context("/libraries"):
             response = self.controller.libraries_opds()
     
             eq_("200 OK", response.status)


### PR DESCRIPTION
Fixes [SIMPLY-1775](https://jira.nypl.org/browse/SIMPLY-1775).