### PR TITLE
Script to reregister all libraries

### DIFF
--- a/bin/registration_refresh
+++ b/bin/registration_refresh
@@ -1,0 +1,9 @@
+#!/usr/bin/env python
+"""Refresh the registration for all registered libraries."""
+import os
+import sys
+bin_dir = os.path.split(__file__)[0]
+package_dir = os.path.join(bin_dir, "..")
+sys.path.append(os.path.abspath(package_dir))
+from scripts import RegistrationRefreshScript
+RegistrationRefreshScript().run()

--- a/scripts.py
+++ b/scripts.py
@@ -86,7 +86,7 @@ class Script(object):
 
 
 class LibraryScript(Script):
-    """A script that operates on one library or all non-cancelled libraries."""
+    """A script that operates on one library or all libraries."""
 
     # If this is True, the script will only ever operate on one library,
     # and which library to use is a required input. If this is False, the
@@ -111,12 +111,21 @@ class LibraryScript(Script):
         if library_name:
             library = get_one(self._db, Library, name=library_name)
             if not library:
-                raise Exception("No library with name %r" % library_name)
+                raise ValueError("No library with name %r" % library_name)
             return [library]
+        return self.all_libraries
+
+    @property
+    def all_libraries(self):
+        """Find an iterator over all libraries, whatever 
+        'all libraries' means in the context of this script.
+
+        By default, 'all libraries' means all libraries in the
+        production or testing stages.
+        """
         return self._db.query(Library).filter(
-            Library._library_stage!=Library.CANCELLED_STAGE).filter(
-                Library.registry_stage!=Library.CANCELLED_STAGE
-            )
+            Library._feed_restriction(production=False)
+        )
 
 
 class LoadPlacesScript(Script):

--- a/scripts.py
+++ b/scripts.py
@@ -117,7 +117,7 @@ class LibraryScript(Script):
 
     @property
     def all_libraries(self):
-        """Find an iterator over all libraries, whatever 
+        """Find an iterator over all libraries, whatever
         'all libraries' means in the context of this script.
 
         By default, 'all libraries' means all libraries in the
@@ -330,9 +330,9 @@ class RegistrationRefreshScript(LibraryScript):
 
     REQUIRES_SINGLE_LIBRARY = False
 
-    def run(self, cmd_args=None, registrar_class=LibraryRegistrar):
+    def run(self, cmd_args=None):
         parsed = self.parse_command_line(self._db, cmd_args)
-        registrar = registrar_class(self._db)
+        registrar = self.registrar
         for library in self.libraries(parsed.library):
             result = registrar.reregister(library)
             if isinstance(result, ProblemDetail):
@@ -346,6 +346,12 @@ class RegistrationRefreshScript(LibraryScript):
                     "SUCCESS %s (%s)", library.name, library.authentication_url
                 )
                 self._db.commit()
+
+    @property
+    def registrar(self):
+        """Overridable method to create a LibraryRegistrar."""
+        return LibraryRegistrar(self._db)
+
 
 class AdobeVendorIDAcceptanceTestScript(Script):
     """Verify basic Adobe Vendor ID functionality, the way Adobe does

--- a/tests/test_scripts.py
+++ b/tests/test_scripts.py
@@ -335,7 +335,7 @@ class TestRegistrationRefreshScript(DatabaseTest):
 
     def test_run(self):
         # Verify that run() instantiates a LibraryRegistrar using .registrar,
-        # then calles its reregister() method on every library that it's
+        # then calls its reregister() method on every library that it's
         # been asked to handle.
         success_library = self._library(name="Success")
         failure_library = self._library(name="Failure")


### PR DESCRIPTION
This branch implements the script necessary for https://jira.nypl.org/browse/SIMPLY-1575. It basically sweeps over all non-cancelled libraries and updates our records based on what their authentication documents say.

Since almost all the work is done inside LibraryRegistrar.reregister(), this branch focuses on improving `LibraryScript` so that you can write a script that will either operate on a single named library or on all libraries.