### PR TITLE
Don't crash if uszipcode is asked to try to find a place that's not in the US.

### DIFF
--- a/model.py
+++ b/model.py
@@ -1338,7 +1338,8 @@ class Place(Base):
         search = uszipcode.SearchEngine(simple_zipcode=True)
         state = self.abbreviated_name
         uszipcode_matches = []
-        if name in search.state_to_city_mapper[state]:
+        if (state in search.state_to_city_mapper
+            and name in search.state_to_city_mapper[state]):
             # The given name is an exact match for one of the
             # cities. Let's look up every ZIP code for that city.
             uszipcode_matches = search.by_city_and_state(

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -358,6 +358,11 @@ class TestPlace(DatabaseTest):
         # Similarly if we ask about a nonexistent place.
         eq_(None, m("ZXCVB"))
 
+        # Or if we try to use uszipcode on a place that's not in the US.
+        ontario = self._place('35', 'Ontario', Place.STATE,
+                              'ON', None, None)
+        eq_(None, ontario.lookup_one_through_external_source('Hamilton'))
+
         # Calling this method on a Place that's not a state doesn't
         # make sense (because uszipcode only knows about cities within
         # states), and the result is always None.


### PR DESCRIPTION
This is a support branch for https://jira.nypl.org/browse/SIMPLY-1845. It stops an unhandled exception when `Place.lookup_one_through_external_source` is asked to find a place inside a Canadian province.

Right now `lookup_one_through_external_source` only knows one way of finding places: using the `uszipcode` library. Obviously Canadian provinces aren't in its `search.state_to_city_mapper` dictionary, and trying to look up a province abbreviation in that dictionary causes the exception.

Instead of crashing, `lookup_one_through_external_source` now does nothing in this case, since the one trick it knows about won't work.