### PR TITLE
Add endpoint for admins to search for a library by name

### DIFF
--- a/app.py
+++ b/app.py
@@ -130,10 +130,10 @@ def libraries():
 def library_details(uuid):
     return app.library_registry.registry_controller.library_details(uuid)
 
-@app.route('/admin/libraries/search_by_name', methods=["POST"])
+@app.route('/admin/libraries/search_details', methods=["POST"])
 @returns_json_or_response_or_problem_detail
-def search_by_name():
-    return app.library_registry.registry_controller.search_by_name()
+def search_details():
+    return app.library_registry.registry_controller.search_details()
 
 @app.route('/admin/libraries/email', methods=["POST"])
 @returns_json_or_response_or_problem_detail

--- a/app.py
+++ b/app.py
@@ -130,6 +130,11 @@ def libraries():
 def library_details(uuid):
     return app.library_registry.registry_controller.library_details(uuid)
 
+@app.route('/admin/libraries/search_by_name', methods=["POST"])
+@returns_json_or_response_or_problem_detail
+def search_by_name():
+    return app.library_registry.registry_controller.search_by_name()
+
 @app.route('/admin/libraries/email', methods=["POST"])
 @returns_json_or_response_or_problem_detail
 def validate_email():

--- a/controller.py
+++ b/controller.py
@@ -341,7 +341,7 @@ class LibraryRegistryController(BaseController):
         session["username"] = "";
         return redirect(url_for('admin_view'))
 
-    def search_by_name(self):
+    def search_details(self):
         name = flask.request.form.get("name")
         search_results = Library.search(self._db, {}, name, production=False)
         if search_results:

--- a/controller.py
+++ b/controller.py
@@ -341,6 +341,14 @@ class LibraryRegistryController(BaseController):
         session["username"] = "";
         return redirect(url_for('admin_view'))
 
+    def search_by_name(self):
+        name = flask.request.form.get("name")
+        search_result = Library.search_by_library_name(self._db, name, production=False).first()
+        if search_result:
+            return self.library_details(search_result.internal_urn.split("uuid:")[1], search_result)
+        else:
+            return LIBRARY_NOT_FOUND
+
     def library(self):
         library = flask.request.library
         this_url = self.app.url_for(

--- a/controller.py
+++ b/controller.py
@@ -343,9 +343,10 @@ class LibraryRegistryController(BaseController):
 
     def search_by_name(self):
         name = flask.request.form.get("name")
-        search_result = Library.search_by_library_name(self._db, name, production=False).first()
-        if search_result:
-            return self.library_details(search_result.internal_urn.split("uuid:")[1], search_result)
+        search_results = Library.search(self._db, {}, name, production=False)
+        if search_results:
+            info = [self.library_details(lib.internal_urn.split("uuid:")[1], lib) for lib in search_results]
+            return dict(libraries=info)
         else:
             return LIBRARY_NOT_FOUND
 

--- a/tests/test_controller.py
+++ b/tests/test_controller.py
@@ -297,7 +297,7 @@ class TestLibraryRegistryController(ControllerTest):
         self._is_library(ct, libraries[0])
         self._is_library(ks, libraries[1])
         self._is_library(nypl, libraries[2])
-    
+
     def test_libraries_opds(self):
         library = self._library(
             name="Test Cancelled Library",
@@ -313,7 +313,7 @@ class TestLibraryRegistryController(ControllerTest):
 
         with self.app.test_request_context("/libraries"):
             response = self.controller.libraries_opds()
-    
+
             eq_("200 OK", response.status)
             eq_(OPDSCatalog.OPDS_TYPE, response.headers['Content-Type'])
 
@@ -330,10 +330,10 @@ class TestLibraryRegistryController(ControllerTest):
 
             eq_("Kansas State Library", ks['metadata']['title'])
             eq_(self.kansas_state_library.internal_urn, ks['metadata']['id'])
-            
+
             eq_("NYPL", nypl['metadata']['title'])
             eq_(self.nypl.internal_urn, nypl['metadata']['id'])
-            
+
             [library_link, register_link, search_link, self_link] = sorted(
                 catalog['links'], key=lambda x: x['rel']
             )
@@ -460,6 +460,27 @@ class TestLibraryRegistryController(ControllerTest):
         eq_(response.status_code, 400)
         eq_(response.detail, 'The contact URI for this library is missing or invalid')
         eq_(response.uri, 'http://librarysimplified.org/terms/problem/invalid-contact-uri')
+
+    def test_search_by_name(self):
+        library = self.nypl
+
+        # Searching for the name of a real library returns that library.
+        with self.app.test_request_context("/", method="POST"):
+            flask.request.form = MultiDict([
+                ("name", "NYPL"),
+            ])
+            response = self.controller.search_by_name()
+
+        self._is_library(library, response)
+
+        # Searching for a name that cannot be found returns a problem detail.
+        with self.app.test_request_context("/", method="POST"):
+            flask.request.form = MultiDict([
+                ("name", "other"),
+            ])
+            response = self.controller.search_by_name()
+
+        eq_(response, LIBRARY_NOT_FOUND)
 
     def _log_in(self):
         flask.request.form = MultiDict([

--- a/tests/test_controller.py
+++ b/tests/test_controller.py
@@ -464,14 +464,16 @@ class TestLibraryRegistryController(ControllerTest):
     def test_search_by_name(self):
         library = self.nypl
 
-        # Searching for the name of a real library returns that library.
+        # Searching for the name of a real library returns a dict whose value is a list containing
+        # that library.
         with self.app.test_request_context("/", method="POST"):
             flask.request.form = MultiDict([
                 ("name", "NYPL"),
             ])
             response = self.controller.search_by_name()
 
-        self._is_library(library, response)
+        for response_library in response.get("libraries"):
+            self._is_library(library, response_library)
 
         # Searching for a name that cannot be found returns a problem detail.
         with self.app.test_request_context("/", method="POST"):

--- a/tests/test_controller.py
+++ b/tests/test_controller.py
@@ -461,7 +461,7 @@ class TestLibraryRegistryController(ControllerTest):
         eq_(response.detail, 'The contact URI for this library is missing or invalid')
         eq_(response.uri, 'http://librarysimplified.org/terms/problem/invalid-contact-uri')
 
-    def test_search_by_name(self):
+    def test_search_details(self):
         library = self.nypl
 
         # Searching for the name of a real library returns a dict whose value is a list containing
@@ -470,7 +470,7 @@ class TestLibraryRegistryController(ControllerTest):
             flask.request.form = MultiDict([
                 ("name", "NYPL"),
             ])
-            response = self.controller.search_by_name()
+            response = self.controller.search_details()
 
         for response_library in response.get("libraries"):
             self._is_library(library, response_library)
@@ -480,7 +480,7 @@ class TestLibraryRegistryController(ControllerTest):
             flask.request.form = MultiDict([
                 ("name", "other"),
             ])
-            response = self.controller.search_by_name()
+            response = self.controller.search_details()
 
         eq_(response, LIBRARY_NOT_FOUND)
 


### PR DESCRIPTION
Server-side work for [the new registry_admin search feature](https://jira.nypl.org/browse/SIMPLY-1887), which enables admins to search for a library by name.