### PR TITLE
Allow TOS to be stored as a small snippet of HTML in addition to a simple link.

### DIFF
--- a/config.py
+++ b/config.py
@@ -39,9 +39,15 @@ class Configuration(object):
     ADOBE_VENDOR_ID_NODE_VALUE = "node_value"
     ADOBE_VENDOR_ID_DELEGATE_URL = "delegate_url"
 
-    # The URL to the document containing the terms of servier for
+    # The URL to the document containing the terms of service for
     # library registration
     REGISTRATION_TERMS_OF_SERVICE_URL = "registration_terms_of_service_url"
+
+    # An HTML snippet describing the terms of service for library
+    # registration. It's better if this is a short snippet of text
+    # with a link, rather than the actual text of the terms of
+    # service.
+    REGISTRATION_TERMS_OF_SERVICE_HTML = "registration_terms_of_service_html"
 
     # Email sent by the library registry will be 'from' this address,
     # and receipients will be invited to contact this address if they

--- a/controller.py
+++ b/controller.py
@@ -410,14 +410,33 @@ class LibraryRegistryController(BaseController):
         URL of the page they're stored.
         """
         document = dict()
+
+        # The terms of service may be encapsulated in a link to
+        # a web page.
         terms_of_service_url = ConfigurationSetting.sitewide(
             self._db, Configuration.REGISTRATION_TERMS_OF_SERVICE_URL
         ).value
+        type = "text/html"
+        rel = "terms-of-service"
         if terms_of_service_url:
             OPDSCatalog.add_link_to_catalog(
-                document, rel="terms-of-service",
-                href=terms_of_service_url
+                document, rel=rel, type=type,
+                href=terms_of_service_url,
             )
+
+        # And/or the terms of service may be described in
+        # human-readable HTML, which we'll present as a data: link.
+        terms_of_service_html = ConfigurationSetting.sitewide(
+            self._db, Configuration.REGISTRATION_TERMS_OF_SERVICE_HTML
+        ).value
+        if terms_of_service_html:
+            encoded = base64.b64encode(terms_of_service_html)
+            terms_of_service_link = "data:%s;base64,%s" % (type, encoded)
+            OPDSCatalog.add_link_to_catalog(
+                document, rel=rel, type=type,
+                href=terms_of_service_link
+            )
+
         return document
 
     def catalog_response(self, document, status=200):


### PR DESCRIPTION
This branch addresses https://jira.nypl.org/browse/SIMPLY-2277. The registry terms of service can be expressed as a simple link, as before, and/or as a snippet of explanatory HTML.