### PR TITLE
Tell the front end how many Adobe IDs are associated with each library

### DIFF
--- a/controller.py
+++ b/controller.py
@@ -284,7 +284,7 @@ class LibraryRegistryController(BaseController):
             internal_urn=library.internal_urn,
             online_registration=str(library.online_registration),
             pls_id=library.pls_id.value,
-            number_of_patrons=library.number_of_patrons(self._db)
+            number_of_patrons=str(library.number_of_patrons)
         )
         urls_and_contact = dict(
             contact_email=contact_email,

--- a/controller.py
+++ b/controller.py
@@ -284,7 +284,7 @@ class LibraryRegistryController(BaseController):
             internal_urn=library.internal_urn,
             online_registration=str(library.online_registration),
             pls_id=library.pls_id.value,
-            number_of_patrons=library.number_of_patrons
+            number_of_patrons=library.number_of_patrons(self._db)
         )
         urls_and_contact = dict(
             contact_email=contact_email,

--- a/controller.py
+++ b/controller.py
@@ -283,7 +283,8 @@ class LibraryRegistryController(BaseController):
             timestamp=library.timestamp,
             internal_urn=library.internal_urn,
             online_registration=str(library.online_registration),
-            pls_id=library.pls_id.value
+            pls_id=library.pls_id.value,
+            number_of_patrons=library.number_of_patrons
         )
         urls_and_contact = dict(
             contact_email=contact_email,

--- a/model.py
+++ b/model.py
@@ -419,15 +419,17 @@ class Library(Base):
     def pls_id(self):
         return ConfigurationSetting.for_library(Library.PLS_ID, self)
 
-    def number_of_patrons(self, _db):
+    @property
+    def number_of_patrons(self):
+        db = Session.object_session(self)
         # This is only meaningful if the library is in production.
         if not self.in_production:
-            return '0'
-        query = _db.query(DelegatedPatronIdentifier).filter(
+            return 0
+        query = db.query(DelegatedPatronIdentifier).filter(
             DelegatedPatronIdentifier.type==DelegatedPatronIdentifier.ADOBE_ACCOUNT_ID,
             DelegatedPatronIdentifier.library_id==self.id
         )
-        return str(query.count())
+        return query.count()
 
     @property
     def in_production(self):

--- a/model.py
+++ b/model.py
@@ -419,12 +419,15 @@ class Library(Base):
     def pls_id(self):
         return ConfigurationSetting.for_library(Library.PLS_ID, self)
 
-    @property
-    def number_of_patrons(self):
+    def number_of_patrons(self, _db):
         # This is only meaningful if the library is in production.
         if not self.in_production:
             return '0'
-        return str(len(filter(lambda id: (id.type == 'Adobe Account ID'), self.delegated_patron_identifiers)))
+        query = _db.query(DelegatedPatronIdentifier).filter(
+            DelegatedPatronIdentifier.type==DelegatedPatronIdentifier.ADOBE_ACCOUNT_ID,
+            DelegatedPatronIdentifier.library_id==self.id
+        )
+        return str(query.count())
 
     @property
     def in_production(self):

--- a/model.py
+++ b/model.py
@@ -420,6 +420,13 @@ class Library(Base):
         return ConfigurationSetting.for_library(Library.PLS_ID, self)
 
     @property
+    def number_of_patrons(self):
+        # This is only meaningful if the library is in production.
+        if not self.in_production:
+            return '0'
+        return str(len(filter(lambda id: (id.type == 'Adobe Account ID'), self.delegated_patron_identifiers)))
+
+    @property
     def in_production(self):
         """Is this library in production?
 

--- a/tests/test_controller.py
+++ b/tests/test_controller.py
@@ -275,7 +275,7 @@ class TestLibraryRegistryController(ControllerTest):
         expected_categories = ['uuid', 'basic_info', 'urls_and_contact', 'stages', 'areas']
         eq_(set(expected_categories), set(library.keys()))
 
-        expected_info_keys = ['name', 'short_name', 'description', 'timestamp', 'internal_urn', 'online_registration', 'pls_id']
+        expected_info_keys = ['name', 'short_name', 'description', 'timestamp', 'internal_urn', 'online_registration', 'pls_id', 'number_of_patrons']
         eq_(set(expected_info_keys), set(library.get("basic_info").keys()))
 
         expected_url_contact_keys = ['contact_email', 'web_url', 'authentication_url', 'validated', 'opds_url']

--- a/tests/test_controller.py
+++ b/tests/test_controller.py
@@ -267,7 +267,7 @@ class TestLibraryRegistryController(ControllerTest):
             elif k == Library.PLS_ID:
                 eq_(flattened.get(k), expected.pls_id.value)
             elif k == "number_of_patrons":
-                eq_(flattened.get(k), expected.number_of_patrons(self._db))
+                eq_(flattened.get(k), str(getattr(expected, k)))
             else:
                 eq_(flattened.get(k), getattr(expected, k))
 

--- a/tests/test_controller.py
+++ b/tests/test_controller.py
@@ -266,6 +266,8 @@ class TestLibraryRegistryController(ControllerTest):
                 eq_(actual_areas, expected_areas)
             elif k == Library.PLS_ID:
                 eq_(flattened.get(k), expected.pls_id.value)
+            elif k == "number_of_patrons":
+                eq_(flattened.get(k), expected.number_of_patrons(self._db))
             else:
                 eq_(flattened.get(k), getattr(expected, k))
 

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -514,6 +514,28 @@ class TestLibrary(DatabaseTest):
         lib.registry_stage = Library.PRODUCTION_STAGE
         eq_(False, lib.in_production)
 
+    def test_number_of_patrons(self):
+        production_library = self._library()
+        eq_(production_library.number_of_patrons, '0')
+        identifier1, is_new = DelegatedPatronIdentifier.get_one_or_create(
+            self._db, production_library, self._str, DelegatedPatronIdentifier.ADOBE_ACCOUNT_ID,
+            None
+        )
+        eq_(production_library.number_of_patrons, '1')
+        # Identifiers that aren't Adobe Account IDs don't count towards the total.
+        identifier2, is_new = DelegatedPatronIdentifier.get_one_or_create(
+            self._db, production_library, self._str, "abc", None
+        )
+        eq_(production_library.number_of_patrons, '1')
+        # Identifiers can't be assigned to libraries that aren't in production.
+        testing_library = self._library(library_stage=Library.TESTING_STAGE)
+        eq_(testing_library.number_of_patrons, '0')
+        identifier3, is_new = DelegatedPatronIdentifier.get_one_or_create(
+            self._db, testing_library, self._str, DelegatedPatronIdentifier.ADOBE_ACCOUNT_ID,
+            None
+        )
+        eq_(testing_library.number_of_patrons, '0')
+
     def test__feed_restriction(self):
         """Test the _feed_restriction helper method."""
 

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -516,25 +516,25 @@ class TestLibrary(DatabaseTest):
 
     def test_number_of_patrons(self):
         production_library = self._library()
-        eq_(production_library.number_of_patrons, '0')
+        eq_(production_library.number_of_patrons(self._db), '0')
         identifier1, is_new = DelegatedPatronIdentifier.get_one_or_create(
             self._db, production_library, self._str, DelegatedPatronIdentifier.ADOBE_ACCOUNT_ID,
             None
         )
-        eq_(production_library.number_of_patrons, '1')
+        eq_(production_library.number_of_patrons(self._db), '1')
         # Identifiers that aren't Adobe Account IDs don't count towards the total.
         identifier2, is_new = DelegatedPatronIdentifier.get_one_or_create(
             self._db, production_library, self._str, "abc", None
         )
-        eq_(production_library.number_of_patrons, '1')
+        eq_(production_library.number_of_patrons(self._db), '1')
         # Identifiers can't be assigned to libraries that aren't in production.
         testing_library = self._library(library_stage=Library.TESTING_STAGE)
-        eq_(testing_library.number_of_patrons, '0')
+        eq_(testing_library.number_of_patrons(self._db), '0')
         identifier3, is_new = DelegatedPatronIdentifier.get_one_or_create(
             self._db, testing_library, self._str, DelegatedPatronIdentifier.ADOBE_ACCOUNT_ID,
             None
         )
-        eq_(testing_library.number_of_patrons, '0')
+        eq_(testing_library.number_of_patrons(self._db), '0')
 
     def test__feed_restriction(self):
         """Test the _feed_restriction helper method."""

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -516,25 +516,25 @@ class TestLibrary(DatabaseTest):
 
     def test_number_of_patrons(self):
         production_library = self._library()
-        eq_(production_library.number_of_patrons(self._db), '0')
+        eq_(production_library.number_of_patrons, 0)
         identifier1, is_new = DelegatedPatronIdentifier.get_one_or_create(
             self._db, production_library, self._str, DelegatedPatronIdentifier.ADOBE_ACCOUNT_ID,
             None
         )
-        eq_(production_library.number_of_patrons(self._db), '1')
+        eq_(production_library.number_of_patrons, 1)
         # Identifiers that aren't Adobe Account IDs don't count towards the total.
         identifier2, is_new = DelegatedPatronIdentifier.get_one_or_create(
             self._db, production_library, self._str, "abc", None
         )
-        eq_(production_library.number_of_patrons(self._db), '1')
+        eq_(production_library.number_of_patrons, 1)
         # Identifiers can't be assigned to libraries that aren't in production.
         testing_library = self._library(library_stage=Library.TESTING_STAGE)
-        eq_(testing_library.number_of_patrons(self._db), '0')
+        eq_(testing_library.number_of_patrons, 0)
         identifier3, is_new = DelegatedPatronIdentifier.get_one_or_create(
             self._db, testing_library, self._str, DelegatedPatronIdentifier.ADOBE_ACCOUNT_ID,
             None
         )
-        eq_(testing_library.number_of_patrons(self._db), '0')
+        eq_(testing_library.number_of_patrons, 0)
 
     def test__feed_restriction(self):
         """Test the _feed_restriction helper method."""


### PR DESCRIPTION
Resolves https://jira.nypl.org/browse/SIMPLY-2348.  (Generating the data for each library, rather than running the query to list all the identifiers, turned out to be a lot easier for getting the information to the front end in a useful format.)