### PR TITLE
Filter out cancelled libraries in libraries_opds

### DIFF
--- a/controller.py
+++ b/controller.py
@@ -251,10 +251,9 @@ class LibraryRegistryController(BaseController):
         """Return all the libraries in OPDS format"""
 
         libraries = self._db.query(Library).order_by(Library.name)
-        # We want to restrict libraries that are either in production
-        # or in the testing stage but not cancelled.
-        if live:
-            libraries = libraries.filter(Library._feed_restriction(production=True))
+        # We always want to filter out cancelled libraries.  If live, we also filter out
+        # libraries that are in the testing stage, i.e. only show production libraries.
+        libraries = libraries.filter(Library._feed_restriction(production=live))
 
         url = self.app.url_for("libraries_opds")
         catalog = OPDSCatalog(

--- a/tests/test_controller.py
+++ b/tests/test_controller.py
@@ -366,9 +366,10 @@ class TestLibraryRegistryController(ControllerTest):
 
             catalog = json.loads(response.data)
 
-            eq_(len(catalog['catalogs']), 4)
+            # The cancelled library got filtered out.
+            eq_(len(catalog['catalogs']), 3)
 
-            [ct, ks, nypl, cancelled_library] = catalog['catalogs']
+            [ct, ks, nypl] = catalog['catalogs']
             eq_("Connecticut State Library", ct['metadata']['title'])
             eq_(self.connecticut_state_library.internal_urn, ct['metadata']['id'])
 
@@ -377,10 +378,6 @@ class TestLibraryRegistryController(ControllerTest):
 
             eq_("NYPL", nypl['metadata']['title'])
             eq_(self.nypl.internal_urn, nypl['metadata']['id'])
-
-            eq_("Test Cancelled Library", cancelled_library['metadata']['title'])
-            eq_(library.internal_urn, cancelled_library['metadata']['id'])
-
 
             [library_link, register_link, search_link, self_link] = sorted(
                 catalog['links'], key=lambda x: x['rel']


### PR DESCRIPTION
Partially resolves https://jira.nypl.org/browse/SIMPLY-2349.  (I think the proposed changes to the admin endpoint can be mostly handled on the front end, so that will be a separate ticket and PR.) 