### PR TITLE
Validate emails to register

### DIFF
--- a/controller.py
+++ b/controller.py
@@ -339,7 +339,9 @@ class LibraryRegistryController(BaseController):
             "help_email": Hyperlink.HELP_REL,
             "copyright_email": Hyperlink.COPYRIGHT_DESIGNATED_AGENT_REL
         }
-        hyperlink = Library.get_hyperlink(library, email_types[email])
+        hyperlink = None
+        if email_types[email]:
+            hyperlink = Library.get_hyperlink(library, email_types[email])
         if not hyperlink or not hyperlink.resource or isinstance(hyperlink, ProblemDetail):
             return INVALID_CONTACT_URI.detailed(
                 "The contact URI for this library is missing or invalid"

--- a/controller.py
+++ b/controller.py
@@ -340,7 +340,7 @@ class LibraryRegistryController(BaseController):
             "copyright_email": Hyperlink.COPYRIGHT_DESIGNATED_AGENT_REL
         }
         hyperlink = None
-        if email_types[email]:
+        if email_types.get(email):
             hyperlink = Library.get_hyperlink(library, email_types[email])
         if not hyperlink or not hyperlink.resource or isinstance(hyperlink, ProblemDetail):
             return INVALID_CONTACT_URI.detailed(

--- a/controller.py
+++ b/controller.py
@@ -270,21 +270,11 @@ class LibraryRegistryController(BaseController):
         if isinstance(library, ProblemDetail):
             return library
 
-        contact_email = None
-        help_email = None
-        copyright_email = None
-
-        contact_email_hyperlink = Library.get_hyperlink(library, Hyperlink.INTEGRATION_CONTACT_REL)
-        contact_email = self._get_email(contact_email_hyperlink)
-        contact_email_validated_at = self._validated_at(contact_email_hyperlink)
-
-        help_email_hyperlink = Library.get_hyperlink(library, Hyperlink.HELP_REL)
-        help_email = self._get_email(help_email_hyperlink)
-        help_email_validated_at = self._validated_at(help_email_hyperlink)
-
-        copyright_email_hyperlink = Library.get_hyperlink(library, Hyperlink.COPYRIGHT_DESIGNATED_AGENT_REL)
-        copyright_email = self._get_email(copyright_email_hyperlink)
-        copyright_email_validated_at = self._validated_at(copyright_email_hyperlink)
+        hyperlink_types = [Hyperlink.INTEGRATION_CONTACT_REL, Hyperlink.HELP_REL, Hyperlink.COPYRIGHT_DESIGNATED_AGENT_REL]
+        hyperlinks = [Library.get_hyperlink(library, x) for x in hyperlink_types]
+        contact_email, help_email, copyright_email = [self._get_email(x) for x in hyperlinks]
+        contact_email_validated_at, help_email_validated_at, copyright_email_validated_at = [self._validated_at(x) for x in hyperlinks]
+        contact_email_hyperlink, help_email_hyperlink, copyright_email_hyperlink = hyperlinks
 
         basic_info = dict(
             name=library.name,

--- a/testing.py
+++ b/testing.py
@@ -156,6 +156,8 @@ class DatabaseTest(object):
         library.registry_stage = registry_stage
         if has_email:
             library.set_hyperlink(Hyperlink.INTEGRATION_CONTACT_REL, "mailto:" + name + "@library.org")
+            library.set_hyperlink(Hyperlink.HELP_REL, "mailto:" + name + "@library.org")
+            library.set_hyperlink(Hyperlink.COPYRIGHT_DESIGNATED_AGENT_REL, "mailto:" + name + "@library.org")
         return library
 
     def _external_integration(self, protocol, goal=None, settings=None,

--- a/tests/test_controller.py
+++ b/tests/test_controller.py
@@ -251,11 +251,11 @@ class TestLibraryRegistryController(ControllerTest):
                 actual_time = [actual_ts.year, actual_ts.month, actual_ts.day]
                 expected_time = [expected_ts.year, expected_ts.month, expected_ts.day]
                 eq_(actual_time, expected_time)
-            elif "_email" in k:
+            elif k.endswith("_email"):
                 if has_email:
                     expected_email = expected.name + "@library.org"
                     eq_(flattened.get(k), expected_email)
-            elif "_validated" in k:
+            elif k.endswith("_validated"):
                 eq_(flattened.get(k), "Not validated")
             elif k == "online_registration":
                 eq_(flattened.get("online_registration"), str(expected.online_registration))

--- a/tests/test_controller.py
+++ b/tests/test_controller.py
@@ -255,8 +255,20 @@ class TestLibraryRegistryController(ControllerTest):
                 if has_email:
                     expected_contact_email = expected.name + "@library.org"
                     eq_(flattened.get("contact_email"), expected_contact_email)
-            elif k == "validated":
-                eq_(flattened.get("validated"), "Not validated")
+            elif k == "help_email":
+                if has_email:
+                    expected_help_email = expected.name + "@library.org"
+                    eq_(flattened.get("help_email"), expected_help_email)
+            elif k == "copyright_email":
+                if has_email:
+                    expected_copyright_email = expected.name + "@library.org"
+                    eq_(flattened.get("copyright_email"), expected_copyright_email)
+            elif k == "contact_validated":
+                eq_(flattened.get("contact_validated"), "Not validated")
+            elif k == "help_validated":
+                eq_(flattened.get("help_validated"), "Not validated")
+            elif k == "copyright_validated":
+                eq_(flattened.get("copyright_validated"), "Not validated")
             elif k == "online_registration":
                 eq_(flattened.get("online_registration"), str(expected.online_registration))
             elif k in ["focus", "service"]:
@@ -273,14 +285,13 @@ class TestLibraryRegistryController(ControllerTest):
 
     def _check_keys(self, library):
         # Helper method to check that the controller is sending the right pieces of information about a library.
-
         expected_categories = ['uuid', 'basic_info', 'urls_and_contact', 'stages', 'areas']
         eq_(set(expected_categories), set(library.keys()))
 
         expected_info_keys = ['name', 'short_name', 'description', 'timestamp', 'internal_urn', 'online_registration', 'pls_id', 'number_of_patrons']
         eq_(set(expected_info_keys), set(library.get("basic_info").keys()))
 
-        expected_url_contact_keys = ['contact_email', 'web_url', 'authentication_url', 'validated', 'opds_url']
+        expected_url_contact_keys = ['contact_email', 'help_email', 'copyright_email', 'web_url', 'authentication_url', 'contact_validated', 'help_validated', 'copyright_validated', 'opds_url']
         eq_(set(expected_url_contact_keys), set(library.get("urls_and_contact")))
 
         expected_area_keys = ['focus', 'service']
@@ -527,6 +538,7 @@ class TestLibraryRegistryController(ControllerTest):
         with self.app.test_request_context("/", method="POST"):
             flask.request.form = MultiDict([
                 ("uuid", "no:such:library"),
+                ("email", "contact_email")
             ])
             response = self.controller.validate_email()
         assert isinstance(response, ProblemDetail)
@@ -542,6 +554,7 @@ class TestLibraryRegistryController(ControllerTest):
         with self.app.test_request_context("/", method="POST"):
             flask.request.form = MultiDict([
                 ("uuid", uuid),
+                ("email", "contact_email")
             ])
             self.controller.validate_email()
 
@@ -555,6 +568,7 @@ class TestLibraryRegistryController(ControllerTest):
         with self.app.test_request_context("/", method="POST"):
             flask.request.form = MultiDict([
                 ("uuid", uuid),
+                ("email", "contact_email")
             ])
             response = self.controller.validate_email()
 

--- a/tests/test_controller.py
+++ b/tests/test_controller.py
@@ -251,24 +251,12 @@ class TestLibraryRegistryController(ControllerTest):
                 actual_time = [actual_ts.year, actual_ts.month, actual_ts.day]
                 expected_time = [expected_ts.year, expected_ts.month, expected_ts.day]
                 eq_(actual_time, expected_time)
-            elif k == "contact_email":
+            elif "_email" in k:
                 if has_email:
-                    expected_contact_email = expected.name + "@library.org"
-                    eq_(flattened.get("contact_email"), expected_contact_email)
-            elif k == "help_email":
-                if has_email:
-                    expected_help_email = expected.name + "@library.org"
-                    eq_(flattened.get("help_email"), expected_help_email)
-            elif k == "copyright_email":
-                if has_email:
-                    expected_copyright_email = expected.name + "@library.org"
-                    eq_(flattened.get("copyright_email"), expected_copyright_email)
-            elif k == "contact_validated":
-                eq_(flattened.get("contact_validated"), "Not validated")
-            elif k == "help_validated":
-                eq_(flattened.get("help_validated"), "Not validated")
-            elif k == "copyright_validated":
-                eq_(flattened.get("copyright_validated"), "Not validated")
+                    expected_email = expected.name + "@library.org"
+                    eq_(flattened.get(k), expected_email)
+            elif "_validated" in k:
+                eq_(flattened.get(k), "Not validated")
             elif k == "online_registration":
                 eq_(flattened.get("online_registration"), str(expected.online_registration))
             elif k in ["focus", "service"]:


### PR DESCRIPTION
This resolves https://jira.nypl.org/browse/SIMPLY-2640--the backend for https://jira.nypl.org/browse/SIMPLY-2605.  (This is just making it possible to validate the other emails from the interface--not requiring that all three emails are validated prior to registration, which will be covered later by https://jira.nypl.org/browse/SIMPLY-2606.)