### PR TITLE
Cache library lists internally

### DIFF
--- a/controller.py
+++ b/controller.py
@@ -234,9 +234,11 @@ class LibraryRegistryController(BaseController):
             )
             return Response(body, 200, headers)
 
-    # We will cache each library list _internally_ for one hour.
-    # This is one part of an overall caching strategy; the goal
-    # of this piece is to reduce the amount of time we spend
+    # We will cache each library list _internally_ for this amount
+    # of time.
+    #
+    # This is one part of an overall caching strategy; the goal of
+    # this server-side piece is to reduce the amount of time we spend
     # constructing OPDS feeds.
     CACHE_LIBRARY_LIST_FOR = datetime.timedelta(minutes=15)
 

--- a/controller.py
+++ b/controller.py
@@ -1,4 +1,5 @@
 from nose.tools import set_trace
+import datetime
 import logging
 import flask
 from flask_babel import lazy_gettext as _
@@ -172,6 +173,7 @@ class LibraryRegistryController(BaseController):
         super(LibraryRegistryController, self).__init__(app)
         self.annotator = LibraryRegistryAnnotator(app)
         self.log = self.app.log
+        self.library_list_cache = dict()
         emailer = None
         try:
             emailer = emailer_class.from_sitewide_integration(self._db)
@@ -232,9 +234,24 @@ class LibraryRegistryController(BaseController):
             )
             return Response(body, 200, headers)
 
+    # We will cache each library list _internally_ for one hour.
+    # This is one part of an overall caching strategy; the goal
+    # of this piece is to reduce the amount of time we spend
+    # constructing OPDS feeds.
+    CACHE_LIBRARY_LIST_FOR = datetime.timedelta(minutes=15)
+
     def libraries(self, live=True):
         # Return a specific set of information about all libraries in production; this generates the library list in the admin interface.
         # If :param live is set to False, libraries in testing will also be shown.
+
+        cache_for = self.CACHE_LIBRARY_LIST_FOR
+        if live in self.library_list_cache:
+            data, cached_at = self.library_list_cache[live]
+            now = datetime.datetime.utcnow()
+            expires = cached_at + cache_for
+            if now <= expires:
+                return data
+
         result = []
         libraries = self._db.query(Library).order_by(Library.name)
 
@@ -245,7 +262,10 @@ class LibraryRegistryController(BaseController):
             uuid = library.internal_urn.split("uuid:")[1]
             result += [self.library_details(uuid, library)]
 
-        return dict(libraries=result)
+        data = dict(libraries=result)
+        now = datetime.datetime.utcnow()
+        self.library_list_cache[live] = (data, now)
+        return data
 
     def libraries_opds(self, live=True):
         """Return all the libraries in OPDS format"""

--- a/tests/test_controller.py
+++ b/tests/test_controller.py
@@ -316,6 +316,45 @@ class TestLibraryRegistryController(ControllerTest):
         self._is_library(ks, libraries[1])
         self._is_library(nypl, libraries[2])
 
+    def test_library_cache(self):
+        now = datetime.datetime.utcnow()
+        cache_for = self.controller.CACHE_LIBRARY_LIST_FOR
+        stale = now - cache_for - cache_for
+        fresh = now - cache_for + datetime.timedelta(minutes=2)
+
+        cache = self.controller.library_list_cache
+
+        cache[True] = ("stale list", stale)
+        cache[False] = ("fresh list", fresh)
+
+        # If we ask for live libraries, we get a list that's stale, so a new list
+        # is generated.
+        response = self.controller.libraries(live=True)
+        libraries = response.get("libraries")
+        eq_(3, len(libraries))
+
+        # The cache has been updated...
+        eq_(response, cache[True][0])
+
+        # with an updated timestamp.
+        new_timestamp = cache[True][1]
+        assert new_timestamp > now
+
+        # The same thing happens if we ask for a list that's not cached at all.
+        del cache[True]
+        response2 = self.controller.libraries(live=True)
+        eq_(response, response2)
+        eq_(response, cache[True][0])
+        newer_timestamp = cache[True][1]
+        assert newer_timestamp > new_timestamp
+
+        # If we ask for QA libraries, we get a list that's fresh from the
+        # cache.
+        eq_("fresh list", self.controller.libraries(live=False))
+
+        # The cache is unaffected.
+        eq_(("fresh list", fresh), cache[False])
+
     def test_libraries_qa_admin(self):
         # Test that the controller returns a specific set of information for each library.
         ct = self.connecticut_state_library


### PR DESCRIPTION
This branch adds a quick and dirty internal cache for the big list of libraries, hopefully dramatically decreasing the time it takes to process the flood of requests to /libraries and /libraries/qa. We're taking other steps on the client side to reduce the number of requests; this is just a first step.