### PR TITLE
Send compressed library lists if the client supports it.

### DIFF
--- a/app.py
+++ b/app.py
@@ -14,6 +14,7 @@ from model import SessionManager, ConfigurationSetting
 from nose.tools import set_trace
 from util.app_server import returns_problem_detail, returns_json_or_response_or_problem_detail
 from app_helpers import (
+    compressible,
     has_library_factory,
     uses_location_factory,
 )
@@ -106,11 +107,13 @@ def confirm_resource(resource_id, secret):
     )
 
 @app.route('/libraries')
+@compressible
 @returns_problem_detail
 def libraries_opds():
     return app.library_registry.registry_controller.libraries_opds()
 
 @app.route('/libraries/qa')
+@compressible
 @returns_problem_detail
 def libraries_qa():
     return app.library_registry.registry_controller.libraries_opds(live=False)

--- a/app_helpers.py
+++ b/app_helpers.py
@@ -65,7 +65,6 @@ def compressible(f):
     def compressor(*args, **kwargs):
         @flask.after_this_request
         def compress(response):
-            set_trace()
             if (response.status_code < 200 or
                 response.status_code >= 300 or
                 'Content-Encoding' in response.headers):

--- a/app_helpers.py
+++ b/app_helpers.py
@@ -77,12 +77,13 @@ def compressible(f):
             if not 'gzip' in accept_encoding.lower():
                 return response
 
-            # At this point we know we'ree going to be changing the
+            # At this point we know we're going to be changing the
             # outgoing response.
 
             # TODO: I understand what direct_passthrough does, but am
-            # not sure what it has to do with this. This is pure
-            # copy-and-paste magic.
+            # not sure what it has to do with this, and commenting it
+            # out doesn't change the results or cause tests to
+            # fail. This is pure copy-and-paste magic.
             response.direct_passthrough = False
 
             buffer = BytesIO()

--- a/app_helpers.py
+++ b/app_helpers.py
@@ -1,4 +1,6 @@
 import flask
+import gzip
+from io import BytesIO
 from functools import wraps
 from nose.tools import set_trace
 from util import GeometryUtility
@@ -44,3 +46,58 @@ def uses_location_factory(app):
             return f(*args,  _location=location, **kwargs)
         return decorated
     return factory
+
+
+def compressible(f):
+    """Decorate a function to make it transparently handle whatever
+    compression the client has announced it supports.
+
+    Currently the only form of compression supported is
+    representation-level gzip compression requested through the
+    Accept-Encoding header.
+
+    This code was modified from
+    http://kb.sites.apiit.edu.my/knowledge-base/how-to-gzip-response-in-flask/,
+    though I don't know if that's the original source; it shows up in
+    a lot of places.
+    """
+    @wraps(f)
+    def compressor(*args, **kwargs):
+        @flask.after_this_request
+        def compress(response):
+            set_trace()
+            if (response.status_code < 200 or
+                response.status_code >= 300 or
+                'Content-Encoding' in response.headers):
+                # Don't encode anything other than a 2xx response
+                # code. Don't encode a response that's
+                # already been encoded.
+                return response
+
+            accept_encoding = flask.request.headers.get('Accept-Encoding', '')
+            if not 'gzip' in accept_encoding.lower():
+                return response
+
+            # At this point we know we'ree going to be changing the
+            # outgoing response.
+
+            # TODO: I understand what direct_passthrough does, but am
+            # not sure what it has to do with this. This is pure
+            # copy-and-paste magic.
+            response.direct_passthrough = False
+
+            buffer = BytesIO()
+            gzipped = gzip.GzipFile(mode='wb', fileobj=buffer)
+            gzipped.write(response.data)
+            gzipped.close()
+            response.data = buffer.getvalue()
+
+            response.headers['Content-Encoding'] = 'gzip'
+            # TODO: This is bad if Vary is already set.
+            response.headers['Vary'] = 'Accept-Encoding'
+            response.headers['Content-Length'] = len(response.data)
+
+            return response
+
+        return f(*args, **kwargs)
+    return compressor


### PR DESCRIPTION
This branch adds compression support to the /libraries and /libraries/qa endpoints if the client requests them using the Accept-Encoding header. The library list compresses from 2.6 megs to 1.9 megs, a 25% improvement. According to @twaddington, the Android HTTP client sends `Accept-Encoding: gzip` by default, so we'll start seeing benefits immediately.

This fixes https://jira.nypl.org/browse/SIMPLY-1778. I talk about a lot of other stuff in that ticket, but it's now covered in other tickets.