### PR TITLE
Omit inline logo images from large feeds ('large' is configurable)

### DIFF
--- a/config.py
+++ b/config.py
@@ -63,6 +63,11 @@ class Configuration(object):
     # nation, we assume that they're talking about this nation.
     DEFAULT_NATION_ABBREVIATION = "default_nation_abbreviation"
 
+    # For performance reasons, a registry may want to omit certain
+    # pieces of information from large feeds. This sitewide setting
+    # controls how big a feed must be to be considered 'large'.
+    LARGE_FEED_SIZE = "large_feed_size"
+
     # The name of the sitewide secret used for admin login.
     SECRET_KEY = u"secret_key"
 

--- a/tests/test_opds.py
+++ b/tests/test_opds.py
@@ -146,6 +146,17 @@ class TestOPDSCatalog(DatabaseTest):
         )
         eq_(set([public_hyperlink, private_hyperlink]), set(Mock.hyperlinks))
 
+        # If library_catalog is passed with include_logo=False,
+        # the (potentially large) inline logo is omitted, 
+        # even though it was included before.
+        catalog = Mock.library_catalog(
+            library, include_logo=False, 
+            url_for=self.mock_url_for
+        )
+        relations = [x.get('rel') for x in catalog['links']]
+        assert OPDSCatalog.THUMBNAIL_REL not in relations
+
+
     def test__hyperlink_args(self):
         """Verify that _hyperlink_args generates arguments appropriate
         for an OPDS 2 link.


### PR DESCRIPTION
This branch adds a sitewide setting "large_feed_size", which is expected to be a number. At this size, a list of libraries is considered 'large' and is subject to different rules. Specifically, the OPDS entries generated for those libraries do not include the inline image containing the library's logo.

This addresses https://jira.nypl.org/browse/SIMPLY-2664 in a way that's easy to scale up, scale down, or remove in the future.