### PR TITLE
Add some tests.

### DIFF
--- a/tests/test_opds.py
+++ b/tests/test_opds.py
@@ -95,20 +95,27 @@ class TestOPDSCatalog(DatabaseTest):
         small_catalog = small_feed.catalog['catalogs']
         eq_([], small_catalog)
 
-    def _test_feed_is_large(self):
+    def test_feed_is_large(self):
         # Verify that the _feed_is_large helper method
         # works whether it's given a Python list or a SQLAlchemy query.
         setting = ConfigurationSetting.sitewide(
             self._db, Configuration.LARGE_FEED_SIZE
         )
         setting.value = 2
-        m = OPDSCatalog.feed_is_large
-        list = [1,2,3]
-        query = self._db.query(libraries)
-        eq_(0, query.count())
+        m = OPDSCatalog._feed_is_large
+        query = self._db.query(Library)
 
-        eq_(True, m(self._db, query))
+        # There are no libraries, and the limit is 2, so a feed of libraries would not be large.
+        eq_(0, query.count())
         eq_(False, m(self._db, query))
+
+        # Make some libraries, and the feed becomes large.
+        [self._library() for x in range(2)]
+        eq_(True, m(self._db, query))
+
+        # It also works with a list.
+        eq_(True, m(self._db, [1,2]))
+        eq_(False, m(self._db, [1]))
 
     def test_library_catalog(self):
 


### PR DESCRIPTION
This branch formalizes a hotfix I had to put into place on production as part of my work on https://jira.nypl.org/browse/SIMPLY-2664.

The code I had works fine if `libraries` is a list, but in real life, `libraries` is a SQLAlchemy query, and you get the size of a SQLAlchemy query with count(), not len()

I'm a little concerned about the performance effects once `libraries` becomes a much more complicated query involving geographic proximity, but there's also going to be a `LIMIT` attached to those queries, so we'll know how big they can get ahead of time. Also, once we're able to use those queries, there will effectively be no 'large' OPDS feeds and we can get rid of this whole thing.