### PR TITLE
Promote nearby libraries to the top of the alphabetical list

### DIFF
--- a/app.py
+++ b/app.py
@@ -108,16 +108,16 @@ def confirm_resource(resource_id, secret):
 
 @app.route('/libraries')
 @compressible
-@has_location
+@uses_location
 @returns_problem_detail
-def libraries_opds():
+def libraries_opds(_location=None):
     return app.library_registry.registry_controller.libraries_opds(location=_location)
 
 @app.route('/libraries/qa')
 @compressible
-@has_location
+@uses_location
 @returns_problem_detail
-def libraries_qa():
+def libraries_qa(_location=None):
     return app.library_registry.registry_controller.libraries_opds(location=_location, live=False)
 
 @app.route('/admin/log_in', methods=["POST"])

--- a/app.py
+++ b/app.py
@@ -108,15 +108,17 @@ def confirm_resource(resource_id, secret):
 
 @app.route('/libraries')
 @compressible
+@has_location
 @returns_problem_detail
 def libraries_opds():
-    return app.library_registry.registry_controller.libraries_opds()
+    return app.library_registry.registry_controller.libraries_opds(location=_location)
 
 @app.route('/libraries/qa')
 @compressible
+@has_location
 @returns_problem_detail
 def libraries_qa():
-    return app.library_registry.registry_controller.libraries_opds(live=False)
+    return app.library_registry.registry_controller.libraries_opds(location=_location, live=False)
 
 @app.route('/admin/log_in', methods=["POST"])
 @returns_problem_detail

--- a/controller.py
+++ b/controller.py
@@ -173,7 +173,6 @@ class LibraryRegistryController(BaseController):
         super(LibraryRegistryController, self).__init__(app)
         self.annotator = LibraryRegistryAnnotator(app)
         self.log = self.app.log
-        self.library_list_cache = dict()
         emailer = None
         try:
             emailer = emailer_class.from_sitewide_integration(self._db)
@@ -234,26 +233,9 @@ class LibraryRegistryController(BaseController):
             )
             return Response(body, 200, headers)
 
-    # We will cache each library list _internally_ for this amount
-    # of time.
-    #
-    # This is one part of an overall caching strategy; the goal of
-    # this server-side piece is to reduce the amount of time we spend
-    # constructing OPDS feeds.
-    CACHE_LIBRARY_LIST_FOR = datetime.timedelta(minutes=15)
-
     def libraries(self, live=True):
         # Return a specific set of information about all libraries in production; this generates the library list in the admin interface.
         # If :param live is set to False, libraries in testing will also be shown.
-
-        cache_for = self.CACHE_LIBRARY_LIST_FOR
-        if live in self.library_list_cache:
-            data, cached_at = self.library_list_cache[live]
-            now = datetime.datetime.utcnow()
-            expires = cached_at + cache_for
-            if now <= expires:
-                return data
-
         result = []
         libraries = self._db.query(Library).order_by(Library.name)
 
@@ -266,7 +248,6 @@ class LibraryRegistryController(BaseController):
 
         data = dict(libraries=result)
         now = datetime.datetime.utcnow()
-        self.library_list_cache[live] = (data, now)
         return data
 
     def libraries_opds(self, live=True):

--- a/controller.py
+++ b/controller.py
@@ -10,10 +10,7 @@ from flask import (
     session,
 )
 import requests
-from sqlalchemy.orm import (
-    defer,
-    joinedload,
-)
+from sqlalchemy.orm import joinedload
 from smtplib import SMTPException
 import json
 from Crypto.PublicKey import RSA

--- a/tests/test_controller.py
+++ b/tests/test_controller.py
@@ -404,7 +404,7 @@ class TestLibraryRegistryController(ControllerTest):
             # The other libraries are still in alphabetical order.
             eq_(
                 [u'Kansas State Library', u'Connecticut State Library',
-                 u'NYPL'], 
+                 u'NYPL'],
                 titles
             )
 
@@ -469,10 +469,9 @@ class TestLibraryRegistryController(ControllerTest):
             # The other libraries are still in alphabetical order.
             eq_(
                 [u'Kansas State Library', u'Connecticut State Library',
-                 u'NYPL'], 
+                 u'NYPL'],
                 titles
             )
-
 
     def test_library_details(self):
         # Test that the controller can look up the complete information for one specific library.

--- a/tests/test_controller.py
+++ b/tests/test_controller.py
@@ -389,6 +389,10 @@ class TestLibraryRegistryController(ControllerTest):
             eq_(OPDSCatalog.OPDS_TYPE, self_link['type'])
 
             # Try again with a location in Kansas.
+            #
+            # See test_app_server.py to verify that @uses_location
+            # converts normal-looking latitude/longitude into this
+            # format.
             with self.app.test_request_context("/libraries"):
                 response = self.controller.libraries_opds(
                     False, location="SRID=4326;POINT(-98 39)"
@@ -450,6 +454,10 @@ class TestLibraryRegistryController(ControllerTest):
             eq_(OPDSCatalog.OPDS_TYPE, self_link['type'])
 
             # Try again with a location in Kansas.
+            #
+            # See test_app_server.py to verify that @uses_location
+            # converts normal-looking latitude/longitude into this
+            # format.
             with self.app.test_request_context("/libraries"):
                 response = self.controller.libraries_opds(
                     location="SRID=4326;POINT(-98 39)"

--- a/tests/test_controller.py
+++ b/tests/test_controller.py
@@ -316,45 +316,6 @@ class TestLibraryRegistryController(ControllerTest):
         self._is_library(ks, libraries[1])
         self._is_library(nypl, libraries[2])
 
-    def test_library_cache(self):
-        now = datetime.datetime.utcnow()
-        cache_for = self.controller.CACHE_LIBRARY_LIST_FOR
-        stale = now - cache_for - cache_for
-        fresh = now - cache_for + datetime.timedelta(minutes=2)
-
-        cache = self.controller.library_list_cache
-
-        cache[True] = ("stale list", stale)
-        cache[False] = ("fresh list", fresh)
-
-        # If we ask for live libraries, we get a list that's stale, so a new list
-        # is generated.
-        response = self.controller.libraries(live=True)
-        libraries = response.get("libraries")
-        eq_(3, len(libraries))
-
-        # The cache has been updated...
-        eq_(response, cache[True][0])
-
-        # with an updated timestamp.
-        new_timestamp = cache[True][1]
-        assert new_timestamp > now
-
-        # The same thing happens if we ask for a list that's not cached at all.
-        del cache[True]
-        response2 = self.controller.libraries(live=True)
-        eq_(response, response2)
-        eq_(response, cache[True][0])
-        newer_timestamp = cache[True][1]
-        assert newer_timestamp > new_timestamp
-
-        # If we ask for QA libraries, we get a list that's fresh from the
-        # cache.
-        eq_("fresh list", self.controller.libraries(live=False))
-
-        # The cache is unaffected.
-        eq_(("fresh list", fresh), cache[False])
-
     def test_libraries_qa_admin(self):
         # Test that the controller returns a specific set of information for each library.
         ct = self.connecticut_state_library

--- a/tests/test_controller.py
+++ b/tests/test_controller.py
@@ -368,6 +368,7 @@ class TestLibraryRegistryController(ControllerTest):
             # The cancelled library got filtered out.
             eq_(len(catalog['catalogs']), 3)
 
+            # The other libraries are in alphabetical order.
             [ct, ks, nypl] = catalog['catalogs']
             eq_("Connecticut State Library", ct['metadata']['title'])
             eq_(self.connecticut_state_library.internal_urn, ct['metadata']['id'])
@@ -386,6 +387,22 @@ class TestLibraryRegistryController(ControllerTest):
             eq_(url_for("libraries_opds"), self_link['href'])
             eq_("self", self_link['rel'])
             eq_(OPDSCatalog.OPDS_TYPE, self_link['type'])
+
+            # Try again with a location in Kansas.
+            with self.app.test_request_context("/libraries"):
+                response = self.controller.libraries_opds(
+                    False, location="SRID=4326;POINT(-98 39)"
+                )
+            catalog = json.loads(response.data)
+            titles = [x['metadata']['title'] for x in catalog['catalogs']]
+
+            # The nearby library is promoted to the top of the list.
+            # The other libraries are still in alphabetical order.
+            eq_(
+                [u'Kansas State Library', u'Connecticut State Library',
+                 u'NYPL'], 
+                titles
+            )
 
     def test_libraries_opds(self):
         library = self._library(
@@ -431,6 +448,22 @@ class TestLibraryRegistryController(ControllerTest):
             eq_(url_for("libraries_opds"), self_link['href'])
             eq_("self", self_link['rel'])
             eq_(OPDSCatalog.OPDS_TYPE, self_link['type'])
+
+            # Try again with a location in Kansas.
+            with self.app.test_request_context("/libraries"):
+                response = self.controller.libraries_opds(
+                    location="SRID=4326;POINT(-98 39)"
+                )
+            catalog = json.loads(response.data)
+            titles = [x['metadata']['title'] for x in catalog['catalogs']]
+
+            # The nearby library is promoted to the top of the list.
+            # The other libraries are still in alphabetical order.
+            eq_(
+                [u'Kansas State Library', u'Connecticut State Library',
+                 u'NYPL'], 
+                titles
+            )
 
 
     def test_library_details(self):

--- a/tests/test_opds.py
+++ b/tests/test_opds.py
@@ -152,7 +152,10 @@ class TestOPDSCatalog(DatabaseTest):
         ConfigurationSetting.sitewide(
             self._db, Configuration.WEB_CLIENT_URL).value = "http://web/{uuid}"
 
-        catalog = Mock.library_catalog(library, url_for=self.mock_url_for)
+        catalog = Mock.library_catalog(
+            library, url_for=self.mock_url_for,
+            web_client_uri_template="http://web/{uuid}"
+        )
         metadata = catalog['metadata']
         eq_(library.name, metadata['title'])
         eq_(library.internal_urn, metadata['id'])

--- a/tests/test_opds.py
+++ b/tests/test_opds.py
@@ -35,6 +35,13 @@ class TestOPDSCatalog(DatabaseTest):
             def annotate_catalog(self, catalog_obj, live=True):
                 catalog_obj.catalog['metadata']['random'] = "Random text inserted by annotator."
 
+        # This template will be used to construct a web client link
+        # for each library.
+        template = "http://web/{uuid}"
+        ConfigurationSetting.sitewide(
+            self._db, Configuration.WEB_CLIENT_URL
+        ).value = template
+
         catalog = OPDSCatalog(
             self._db, "A Catalog!", "http://url/", [l1, l2],
             TestAnnotator(), url_for=self.mock_url_for
@@ -53,6 +60,18 @@ class TestOPDSCatalog(DatabaseTest):
 
         # Each library became a catalog in the catalogs collection.
         eq_([l1.name, l2.name], [x['metadata']['title'] for x in parsed['catalogs']])
+
+        # Each library has a link to its web catalog.
+        l1_links, l2_links = [
+            library['links'] for library in parsed['catalogs']
+        ]
+        [l1_web] = [link['href'] for link in l1_links
+                    if link['type'] == 'text/html']
+        eq_(l1_web, template.replace("{uuid}", l1.internal_urn))
+
+        [l2_web] = [link['href'] for link in l2_links
+                    if link['type'] == 'text/html']
+        eq_(l2_web, template.replace("{uuid}", l2.internal_urn))
 
     def test_large_feeds_treated_differently(self):
         # The libraries in large feeds are converted to JSON in ways
@@ -148,9 +167,6 @@ class TestOPDSCatalog(DatabaseTest):
             Hyperlink.HELP_REL,
             "mailto:help@library.org"
         )
-
-        ConfigurationSetting.sitewide(
-            self._db, Configuration.WEB_CLIENT_URL).value = "http://web/{uuid}"
 
         catalog = Mock.library_catalog(
             library, url_for=self.mock_url_for,


### PR DESCRIPTION
This branch addresses https://jira.nypl.org/browse/SIMPLY-2703. The goal is to buy time for the client-side "onboarding" work by promoting libraries near a patron's current location (to help people in the common case), while still showing a big alphabetical library list (since there is no search functionality to help in the uncommon case).

Since different patrons now get different library feeds, I had to remove the caching code. While doing this I discovered that the caching code didn't actually do much, because I'd added it to the controller used by the admin interface (libraries), not the controller used by the mobile clients (libraries_opds). 

I also discovered some significant performance problems building the library feed, caused by having to go to the database to get the contact information for each library. I solved this using the same `joinedload` technique I've used elsewhere in this system -- this fetches related data model objects from the database at the same time as the `Library` objects we request.

These performance problems aren't nearly as bad in production as they are on my laptop (1.5 seconds to get a feed vs 20 seconds), possibly because the production server and the database are on the same network, but I was able to speed this up 4x locally by not going to the database, and we should see a proportional improvement in production.