### PR TITLE
Remove conflicting server block from nginx conf

### DIFF
--- a/docker/nginx.conf
+++ b/docker/nginx.conf
@@ -32,15 +32,8 @@ http {
     }
 
     server {
-        listen 80 default_server;
-        # If no host match, close connection to prevent spoofing
-        return 444;
-    }
-
-    server {
         listen 80 deferred;
         client_max_body_size 4G;
-        server_name localhost;
         keepalive_timeout 5;
 
         location ~ ^/static/.*\.(css|js|eot|svg|ttf)$ {


### PR DESCRIPTION
Fixes a bug where the container's Nginx responded only to requests explicitly to `localhost`, because there was an overriding `server` block that was mis-routing requests.