### PR TITLE
Make it possible to obtain a human-readable description of a library's service area

### DIFF
--- a/model.py
+++ b/model.py
@@ -437,6 +437,42 @@ class Library(Base):
         prod = self.PRODUCTION_STAGE
         return self.library_stage == prod and self.registry_stage == prod
 
+    @property
+    def service_area_name(self):
+        """Describe the library's service area in a short string a human would
+        understand, e.g. "Kern County, CA".
+
+        TODO: We'll want to fetch a library's ServiceAreas (and their
+        Places) as part of the library query so that this doesn't result
+        in extra DB queries per library.
+
+        :return: A string, or None if the library's service area can't be
+           described as a short string.
+        """
+        # Group the service areas by type.
+        by_type = defaultdict(list)
+        for a in self.service_areas:
+            if a.place.type == Place.EVERYWHERE:
+                # We already know that 'everywhere' won't work. Ignore
+                # it so it doesn't mask something more specific.
+                continue
+            by_type[a.type].append(a)
+
+        # If there is a single focus area, use it.
+        # Otherwise, if there is a single eligibility area, use it.
+        service_area = None
+        for area_type in ServiceArea.FOCUS_TYPE, ServiceArea.ELIGIBILITY_TYPE:
+            if len(by_type[area_type]) == 1:
+                [service_area] = by_type[area_type]
+                break
+
+        if service_area:
+            return service_area.human_friendly_name
+
+        # This library does not have one service area that stands out,
+        # so we can't describe it with a short string.
+        return None            
+
     @classmethod
     def _feed_restriction(cls, production, library_field=None, registry_field=None):
         """Create a SQLAlchemy restriction that only finds libraries that
@@ -1266,7 +1302,36 @@ class Place(Base):
         touches = func.ST_Touches(Place.geometry, self.geometry)
         return qu.filter(intersects).filter(touches==False)
 
+    @property
+    def human_friendly_name(self):
+        """Generate the sort of string a human would recognize as an
+        unambiguous name of this place.
+
+        This is in some sense the opposite of parse_name.
+
+        :return: A string, or None if there is no human-friendly name for
+           this place.
+        """
+        if self.type == self.EVERYWHERE:
+            # 'everywhere' is not a distinct place with a well-known name.
+            return None
+        if self.parent and self.parent.type == self.STATE:
+            parent = self.parent.abbreviated_name or self.parent.name
+            if self.type == Place.COUNTY:
+                # Renfrew County, ON
+                return "{} County, {}".format(self.name, parent)
+            elif self.type == Place.CITY:
+                # Montgomery, AL
+                return "{}, {}".format(self.name, parent)
+
+        # All other cases:
+        #  93203
+        #  Texas
+        #  United States
+        return self.name
+
     def lookup_inside(self, name, using_overlap=False, using_external_source=True):
+
         """Look up a named Place that is geographically 'inside' this Place.
 
         :param name: The name of a place, such as "Boston" or

--- a/model.py
+++ b/model.py
@@ -1,3 +1,4 @@
+from collections import defaultdict
 from config import Configuration
 from flask_babel import lazy_gettext as _
 from flask_bcrypt import (
@@ -442,35 +443,41 @@ class Library(Base):
         """Describe the library's service area in a short string a human would
         understand, e.g. "Kern County, CA".
 
+        This library does the best it can to express a library's service
+        area as the name of a single place, but it's not always possible
+        since libraries can have multiple service areas.
+
         TODO: We'll want to fetch a library's ServiceAreas (and their
-        Places) as part of the library query so that this doesn't result
-        in extra DB queries per library.
+        Places) as part of the query that fetches libraries, so that
+        this doesn't result in extra DB queries per library.
 
         :return: A string, or None if the library's service area can't be
            described as a short string.
         """
-        # Group the service areas by type.
-        by_type = defaultdict(list)
+        # Group the ServiceAreas by type.
+        by_type = defaultdict(set)
         for a in self.service_areas:
+            if not a.place:
+                continue
             if a.place.type == Place.EVERYWHERE:
                 # We already know that 'everywhere' won't work. Ignore
                 # it so it doesn't mask something more specific.
                 continue
-            by_type[a.type].append(a)
+            by_type[a.type].add(a)
 
         # If there is a single focus area, use it.
-        # Otherwise, if there is a single eligibility area, use it.
+        # Otherwise, if there is a single eligibility area, use that.
         service_area = None
-        for area_type in ServiceArea.FOCUS_TYPE, ServiceArea.ELIGIBILITY_TYPE:
+        for area_type in ServiceArea.FOCUS, ServiceArea.ELIGIBILITY:
             if len(by_type[area_type]) == 1:
                 [service_area] = by_type[area_type]
                 break
 
         if service_area:
-            return service_area.human_friendly_name
+            return service_area.place.human_friendly_name
 
-        # This library does not have one service area that stands out,
-        # so we can't describe it with a short string.
+        # This library does not have one ServiceArea that stands out,
+        # so we can't describe its service area with a short string.
         return None            
 
     @classmethod
@@ -1290,6 +1297,34 @@ class Place(Base):
         """
         return [x.strip() for x in reversed(name.split(",")) if x.strip()]
 
+    @property
+    def human_friendly_name(self):
+        """Generate the sort of string a human would recognize as an
+        unambiguous name for this place.
+
+        This is in some sense the opposite of parse_name.
+
+        :return: A string, or None if there is no human-friendly name for
+           this place.
+        """
+        if self.type == self.EVERYWHERE:
+            # 'everywhere' is not a distinct place with a well-known name.
+            return None
+        if self.parent and self.parent.type == self.STATE:
+            parent = self.parent.abbreviated_name or self.parent.external_name
+            if self.type == Place.COUNTY:
+                # Renfrew County, ON
+                return "{} County, {}".format(self.external_name, parent)
+            elif self.type == Place.CITY:
+                # Montgomery, AL
+                return "{}, {}".format(self.external_name, parent)
+
+        # All other cases:
+        #  93203
+        #  Texas
+        #  France
+        return self.external_name
+
     def overlaps_not_counting_border(self, qu):
         """Modifies a filter to find places that have points inside this
         Place, not counting the border.
@@ -1301,34 +1336,6 @@ class Place(Base):
         intersects = Place.geometry.intersects(self.geometry)
         touches = func.ST_Touches(Place.geometry, self.geometry)
         return qu.filter(intersects).filter(touches==False)
-
-    @property
-    def human_friendly_name(self):
-        """Generate the sort of string a human would recognize as an
-        unambiguous name of this place.
-
-        This is in some sense the opposite of parse_name.
-
-        :return: A string, or None if there is no human-friendly name for
-           this place.
-        """
-        if self.type == self.EVERYWHERE:
-            # 'everywhere' is not a distinct place with a well-known name.
-            return None
-        if self.parent and self.parent.type == self.STATE:
-            parent = self.parent.abbreviated_name or self.parent.name
-            if self.type == Place.COUNTY:
-                # Renfrew County, ON
-                return "{} County, {}".format(self.name, parent)
-            elif self.type == Place.CITY:
-                # Montgomery, AL
-                return "{}, {}".format(self.name, parent)
-
-        # All other cases:
-        #  93203
-        #  Texas
-        #  United States
-        return self.name
 
     def lookup_inside(self, name, using_overlap=False, using_external_source=True):
 

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -187,6 +187,32 @@ class TestPlace(DatabaseTest):
         assert m("Anytown, USA") == ["USA", "Anytown"]
         assert m("Lake County, Ohio, US") == ["US", "Ohio", "Lake County"]
 
+    def test_human_friendly_name(self):
+        # Verify that places of different types are given good-looking
+        # human-friendly names.
+
+        everywhere = self._place(type=Place.EVERYWHERE)
+        eq_(None, everywhere.human_friendly_name)
+
+        nation = self._place(external_name="United States", type=Place.NATION)
+        eq_("United States", nation.human_friendly_name)
+
+        state = self._place(external_name="Alabama", abbreviated_name="AL"
+                            type=Place.STATE, parent=nation)
+        eq_("Alabama", state.human_friendly_name)
+
+        city = self._place(external_name="Montgomery", type=Place.CITY, 
+                           parent=state)
+        eq_("Montgomery, AL", city.human_friendly_name)
+
+        county = self._place(external_name="Montgomery", type=Place.COUNTY, 
+                             parent=state)
+        eq_("Montgomery County, AL", city.human_friendly_name)
+
+        postal_code = self._place(external_name="36043", type=Place.POSTAL_CODE,
+                                  parent=state)
+        eq_("36043", postal_code.human_friendly_name)
+
     def test_lookup_by_name(self):
 
         # There are two places in California called 'Santa Barbara': a

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -188,30 +188,37 @@ class TestPlace(DatabaseTest):
         assert m("Lake County, Ohio, US") == ["US", "Ohio", "Lake County"]
 
     def test_human_friendly_name(self):
-        # Verify that places of different types are given good-looking
+        # Places of different types are given good-looking
         # human-friendly names.
 
-        everywhere = self._place(type=Place.EVERYWHERE)
-        eq_(None, everywhere.human_friendly_name)
-
         nation = self._place(external_name="United States", type=Place.NATION)
-        eq_("United States", nation.human_friendly_name)
+        assert "United States" == nation.human_friendly_name
 
-        state = self._place(external_name="Alabama", abbreviated_name="AL"
+        state = self._place(external_name="Alabama", abbreviated_name="AL",
                             type=Place.STATE, parent=nation)
-        eq_("Alabama", state.human_friendly_name)
+        assert "Alabama" == state.human_friendly_name
 
         city = self._place(external_name="Montgomery", type=Place.CITY, 
                            parent=state)
-        eq_("Montgomery, AL", city.human_friendly_name)
+        assert "Montgomery, AL" == city.human_friendly_name
 
         county = self._place(external_name="Montgomery", type=Place.COUNTY, 
                              parent=state)
-        eq_("Montgomery County, AL", city.human_friendly_name)
+        assert "Montgomery County, AL" == county.human_friendly_name
 
         postal_code = self._place(external_name="36043", type=Place.POSTAL_CODE,
                                   parent=state)
-        eq_("36043", postal_code.human_friendly_name)
+        assert "36043" == postal_code.human_friendly_name
+
+        # This shouldn't happen, but just in case: the state's full
+        # name is used if it has no abbreviated name.
+        state.abbreviated_name = None
+        assert "Montgomery, Alabama" == city.human_friendly_name
+        assert "Montgomery County, Alabama" == county.human_friendly_name
+
+        # 'everywhere' is not a distinct place with a well-known name.
+        everywhere = self._place(type=Place.EVERYWHERE)
+        assert None == everywhere.human_friendly_name
 
     def test_lookup_by_name(self):
 
@@ -630,10 +637,67 @@ class TestLibrary(DatabaseTest):
 
     def test_library_service_area(self):
         zip = self.zip_10018
+
         nypl = self._library("New York Public Library", eligibility_areas=[zip])
         [service_area] = nypl.service_areas
         assert service_area.place == zip
         assert service_area.library == nypl
+
+    def test_service_area_name(self):
+
+        # Gather a few focus areas; the details don't matter.
+        zip = self.zip_10018
+        nyc = self.new_york_city
+        new_york = self.new_york_state
+
+        # 'Everywhere' is not a place with a distinctive name, so throughout
+        # this test it will be ignored.
+        everywhere = Place.everywhere(self._db)
+
+        library = self._library(
+            "Internet Archive", eligibility_areas=[everywhere],
+            focus_areas=[everywhere]
+        )
+        assert None == library.service_area_name
+
+        # A library with a single eligibility area has a
+        # straightforward name.
+        library = self._library(
+            "test library", eligibility_areas=[everywhere, new_york],
+            focus_areas=[everywhere]
+        )
+        assert "New York" == library.service_area_name
+
+        # If you somehow specify the same place twice, it's fine.
+        library = self._library(
+            "test library", eligibility_areas=[new_york, new_york],
+            focus_areas=[everywhere]
+        )
+        assert "New York" == library.service_area_name
+
+        # If the library has an eligibility area and a focus area,
+        # the focus area takes precedence.
+        library = self._library(
+            "test library", eligibility_areas=[everywhere, new_york],
+            focus_areas=[nyc, everywhere]
+        )
+        assert "New York, NY" == library.service_area_name
+
+        # If there are multiple focus areas and one eligibility area,
+        # we're back to using the focus area.
+        library = self._library(
+            "test library", eligibility_areas=[everywhere, new_york],
+            focus_areas=[nyc, zip, everywhere]
+        )
+        assert "New York" == library.service_area_name
+
+        # If there are multiple focus areas _and_ multiple eligibility areas,
+        # there's no one string that describes the service area.
+        library = self._library(
+            "test library", eligibility_areas=[everywhere, new_york, zip],
+            focus_areas=[nyc, zip, everywhere]
+        )
+        assert None == library.service_area_name
 
     def test_relevant_audience(self):
         research = self._library(


### PR DESCRIPTION
This branch implements the core code necessary to fix https://jira.nypl.org/browse/SIMPLY-3456. If it's reasonable to associate a library with one specific place, the `Library.service_area_name` property will give you the name of that place.

All that remains is adding this information to the`metadata` section when generating a library's OPDS 2 entry. Since we need to keep two different OPDS 2 generators running in parallel (one for the huge list of 300 libraries, one for the smaller list that contains more information about fewer libraries), I added this to https://jira.nypl.org/browse/SIMPLY-3660 rather than putting the code in place as part of this branch.

