### PR TITLE
Switch from nose to pytest.

### DIFF
--- a/tests/test_util_string_helpers.py
+++ b/tests/test_util_string_helpers.py
@@ -1,10 +1,7 @@
 # encoding: utf-8
 # Test the helper objects in util.string.
+import pytest
 
-from nose.tools import (
-    assert_raises,
-    eq_,
-)
 import base64 as stdlib_base64
 import random
 import re
@@ -28,11 +25,8 @@ class TestUnicodeAwareBase64(object):
         # If UnicodeAwareBase64 is given a string it can't encode in
         # its chosen encoding, an exception is the result.
         shift_jis = UnicodeAwareBase64("shift-jis")
-        assert_raises(
-            UnicodeEncodeError,
-            shift_jis.b64encode,
-            string
-        )
+        with pytest.raises(UnicodeEncodeError):
+            shift_jis.b64encode(string)
 
     def _test_encoder(self, string, base64):
         # Create a binary version of the string in the encoder's
@@ -52,7 +46,7 @@ class TestUnicodeAwareBase64(object):
             # then decoding it should give the original string.
             encoded = encode_method(string)
             decoded = decode_method(encoded)
-            eq_(string, decoded)
+            assert string == decoded
 
             # Test encoding on its own. Encoding with a
             # UnicodeAwareBase64 and then converting to ASCII should
@@ -61,34 +55,34 @@ class TestUnicodeAwareBase64(object):
             # module.
             base_encode = getattr(stdlib_base64, encode)
             base_encoded = base_encode(binary)
-            eq_(base_encoded, encoded.encode("ascii"))
+            assert base_encoded == encoded.encode("ascii")
 
             # If you pass in a bytes object to a UnicodeAwareBase64
             # method, it's no problem. You get a Unicode string back.
-            eq_(encoded, encode_method(binary))
-            eq_(decoded, decode_method(base_encoded))
+            assert encoded == encode_method(binary)
+            assert decoded == decode_method(base_encoded)
 
     def test_default_is_base64(self):
         # If you import "base64" from util.string, you get a
         # UnicodeAwareBase64 object that encodes as UTF-8 by default.
         assert isinstance(base64, UnicodeAwareBase64)
-        eq_("utf8", base64.encoding)
+        assert "utf8" == base64.encoding
         snowman = u"☃"
         snowman_utf8 = snowman.encode("utf8")
         as_base64 = base64.b64encode(snowman)
-        eq_("4piD", as_base64)
+        assert "4piD" == as_base64
 
         # This is a Unicode representation of the string you'd get if
         # you encoded the snowman as UTF-8, then used the standard
         # library to base64-encode the bytestring.
-        eq_(b"4piD", stdlib_base64.b64encode(snowman_utf8))
+        assert b"4piD" == stdlib_base64.b64encode(snowman_utf8)
 
 
 class TestRandomstring(object):
 
     def test_random_string(self):
         m = random_string
-        eq_("", m(0))
+        assert "" == m(0)
 
         # The strings are random.
         res1 = m(8)
@@ -104,8 +98,8 @@ class TestRandomstring(object):
             assert isinstance(x, str)
 
             # The strings are entirely composed of lowercase hex digits.
-            eq_(None, re.compile("[^a-f0-9]").search(x))
+            assert re.compile("[^a-f0-9]").search(x) is None
 
             # Each byte is represented as two digits, so the length of the
             # string is twice the length passed in to the function.
-            eq_(size*2, len(x))
+            assert size*2 == len(x)


### PR DESCRIPTION

## Description

Fix some tests to use pytest, instead of nose.

## Motivation and Context

`nose` is not currently a dependency and tests on merged #181 ([commit 833b892](https://github.com/NYPL-Simplified/library_registry/commit/833b8927c197248b47ff611ca676e591df6ccbc5)) were failing.

## How Has This Been Tested?

Ran tests with `pytest -x tests`.

## Checklist:

- [ ] I have updated the documentation accordingly.
- [X] All new and existing tests passed.
