### PR TITLE
Send the human-friendly name of a place to the admin interface rather than using a custom naming system

### DIFF
--- a/controller.py
+++ b/controller.py
@@ -361,8 +361,7 @@ class LibraryRegistryController(BaseController):
         return result
 
     def _format_place_name(self, place):
-        parent_name = (place.parent.abbreviated_name or place.parent.external_name) if place.parent else "unknown"
-        return "%s (%s)" %(place.external_name, parent_name)
+        return place.human_friendly_name or 'Everywhere'
 
     def _get_email(self, hyperlink):
         if hyperlink and hyperlink.resource and hyperlink.resource.href:


### PR DESCRIPTION
Now that we've implemented https://jira.nypl.org/browse/SIMPLY-3456, which gives us a human-friendly name of a library's service area, we're in a good position to address https://jira.nypl.org/browse/SIMPLY-3627 by sending that human-friendly name over to the admin interface as part of a JSON payload. This replaces a similar algorithm which sometimes left it unclear what type of place was being referred to.

I don't think this will require any changes to the admin interface itself, but you know best. 

See [here](https://github.com/NYPL-Simplified/library_registry/blob/develop/model.py#L1301) for the implementation of human_friendly_name and [here](https://github.com/NYPL-Simplified/library_registry/blob/develop/tests/test_model.py#L190) for a test with everal examples.