### PR TITLE
SIMPLY-3719: Make originating_ip() resilient to varied input

### DIFF
--- a/tests/test_flask_util.py
+++ b/tests/test_flask_util.py
@@ -1,4 +1,5 @@
 import ipaddress
+import re
 
 import pytest
 from flask import Flask, request
@@ -6,6 +7,7 @@ from flask import Flask, request
 from util.flask_util import (
     is_public_ipv4_address,
     originating_ip,
+    IPV4_REGEX,
 )
 
 
@@ -15,6 +17,31 @@ def generic_app_obj():
 
 
 class TestFlaskUtil:
+    @pytest.mark.parametrize(
+        "ip_string,result",
+        [
+            pytest.param('127.0.0.1', ['127.0.0.1'], id="single_valid_ip"),
+            pytest.param('300.0.0.1', [], id="invalid_ip_quad_one"),
+            pytest.param('200.300.0.1', [], id="invalid_ip_quad_two"),
+            pytest.param('200.0.300.1', [], id="invalid_ip_quad_three"),
+            pytest.param('200.0.0.300', [], id="invalid_ip_quad_four"),
+            pytest.param('300.300.300.300', [], id="invalid_ip_all_quads"),
+            pytest.param('abc200.100.100.5abc', ['200.100.100.5'], id="non_numeric_prefix_and_postfix"),
+            pytest.param('300.300.300.300 100.100.100.100', ['100.100.100.100'], id="mixed_valid_and_invalid"),
+            pytest.param('64.234.82.200 and also 75.245.93.211', ['64.234.82.200', '75.245.93.211'], id="words"),
+            pytest.param('64.234.82.200,75.245.93.211', ['64.234.82.200', '75.245.93.211'], id="comma_sep_valid_ips"),
+            pytest.param('64.234.82.200 75.245.93.211', ['64.234.82.200', '75.245.93.211'], id="space_sep_valid_ips"),
+            pytest.param('64.234.82.200, 75.245.93.211', ['64.234.82.200', '75.245.93.211'], id="multi_sep_valid_ips"),
+        ]
+    )
+    def test_ipv4_regex(self, ip_string, result):
+        """
+        GIVEN: A string which may contain one or more IPv4 addresses in dot-separated quad form
+        WHEN:  re.findall(IPV4_REGEX, ip_string) is called
+        THEN:  A list returning all valid IPv4 addresses extracted from the string is returned
+        """
+        assert re.findall(IPV4_REGEX, ip_string) == result
+
     @pytest.mark.parametrize(
         "fwd4_value,remote_addr,result",
         [

--- a/tests/test_flask_util.py
+++ b/tests/test_flask_util.py
@@ -1,0 +1,68 @@
+import ipaddress
+
+import pytest
+from flask import Flask, request
+
+from util.flask_util import (
+    is_public_ipv4_address,
+    originating_ip,
+)
+
+
+@pytest.fixture
+def generic_app_obj():
+    return Flask(__name__)
+
+
+class TestFlaskUtil:
+    @pytest.mark.parametrize(
+        "fwd4_value,remote_addr,result",
+        [
+            pytest.param('64.234.82.200', '64.234.82.201', '64.234.82.200', id="ip_from_Fwd4_header"),
+            pytest.param('10.0.0.1', '64.234.82.200', '64.234.82.200', id="ip_from_remote_addr"),
+            pytest.param('10.0.0.1', '10.0.0.2', None, id="no_public_ip_provided"),
+            pytest.param('64.234.82.200, 10.0.0.1', '64.234.82.201', '64.234.82.200', id="multival_Fwd4"),
+        ]
+    )
+    def test_originating_ip(self, generic_app_obj, fwd4_value, remote_addr, result):
+        """
+        GIVEN: A request object with values in the 'X-Forwarded-For' header and remote_addr
+        WHEN:  originating_ip() is called
+        THEN:  The appropriate value (an IP address or None) should be returned
+        """
+        fwd4_header = 'X-Forwarded-For'
+        headers = {fwd4_header.upper(): fwd4_value}
+        env_base = {'REMOTE_ADDR': remote_addr}
+        with generic_app_obj.test_request_context(headers=headers, environ_base=env_base):
+            assert request.headers.get(fwd4_header) == fwd4_value
+            assert request.remote_addr == remote_addr
+
+            if result is None or isinstance(result, bool):
+                assert originating_ip() is result
+            else:
+                assert originating_ip() == result
+
+    @pytest.mark.parametrize(
+        "address,result", [
+            (ipaddress.ip_address('64.234.82.200'), True),  # IPv4Address object arg
+            ('not an ip address', None),    # Bad input
+            ('10.0.0.1', False),            # Private
+            ('224.0.0.3', False),           # Multicast
+            ('0.0.0.0', False),             # Unspecified
+            ('240.0.0.1', False),           # Reserved
+            ('127.0.0.1', False),           # Loopback
+            ('169.254.0.1', False),         # Link local
+            ('255.255.255.255', False),     # Broadcast
+            ('64.234.82.200', True),        # Public
+        ]
+    )
+    def test_is_public_ipv4_address(self, address, result):
+        """
+        GIVEN: A string representation of an IPv4 address
+        WHEN:  is_public_ipv4_address() is called on that string
+        THEN:  The appropriate boolean response should be returned
+        """
+        if not result or isinstance(result, bool):
+            assert is_public_ipv4_address(address) is result
+        else:
+            assert is_public_ipv4_address(address) == result

--- a/util/flask_util.py
+++ b/util/flask_util.py
@@ -2,26 +2,27 @@
 import flask
 from flask import Response
 
-from . import (
-    problem_detail,
-)
-
+from . import problem_detail
 from .language import languages_from_accept
+
 
 def problem_raw(type, status, title, detail=None, instance=None, headers={}):
     data = problem_detail.json(type, status, title, detail, instance)
-    final_headers = { "Content-Type" : problem_detail.JSON_MEDIA_TYPE }
+    final_headers = {"Content-Type": problem_detail.JSON_MEDIA_TYPE}
     final_headers.update(headers)
     return status, final_headers, data
+
 
 def problem(type, status, title, detail=None, instance=None, headers={}):
     """Create a Response that includes a Problem Detail Document."""
     status, headers, data = problem_raw(
         type, status, title, detail, instance, headers)
     return Response(data, status, headers)
-    
+
+
 def languages_for_request():
     return languages_from_accept(flask.request.accept_languages)
+
 
 def originating_ip():
     """If there is an X-Forwarded-For header, use its value as the

--- a/util/flask_util.py
+++ b/util/flask_util.py
@@ -1,9 +1,51 @@
 """Utilities for Flask applications."""
-import flask
-from flask import Response
+import re
+import ipaddress
+
+from flask import request, Response
 
 from . import problem_detail
 from .language import languages_from_accept
+
+
+def is_public_ipv4_address(ip_string):
+    """Whether a given IPv4 address (either string or ipaddress.IPv4Address) is publicly routable"""
+    if not isinstance(ip_string, ipaddress.IPv4Address):
+        try:
+            ip_string = ipaddress.ip_address(ip_string)
+        except ValueError:
+            pass             # TODO: Log it. Some caller is passing bad values to this fn.
+            return None      # incoming value couldn't be coerced to an IPv4Address object
+
+    return bool(
+        ip_string.is_private     is False and     # noqa: E272
+        ip_string.is_multicast   is False and     # noqa: E272
+        ip_string.is_unspecified is False and     # noqa: E272
+        ip_string.is_reserved    is False and     # noqa: E272
+        ip_string.is_loopback    is False and     # noqa: E272
+        ip_string.is_link_local  is False         # noqa: E272
+    )
+
+
+IPV4_REGEX = re.compile(r"""(?P<address>              # entire address, capturing
+                            (?:                       # quads 1-3 and separator, non-capturing
+                                (?:                   # quad value, non-capturing
+                                    25[0-5]       |   # triple digit 250-255
+                                    2[0-4][0-9]   |   # triple digit 200-249
+                                    1[0-9]{2}     |   # triple digit 100-199
+                                    [1-9][0-9]    |   # double digit  10-99
+                                    [0-9]             # single digit   0-9
+                                )\.                   # dot separator
+                            ){3}
+                            (?:                       # quad 4, non-capturing
+                                25[0-5]           |   # triple digit 250-255
+                                2[0-4][0-9]       |   # triple digit 200-249
+                                1[0-9]{2}         |   # triple digit 100-199
+                                [1-9][0-9]        |   # double digit  10-99
+                                [0-9]                 # single digit   0-9
+                            )
+                          )
+                          """, re.VERBOSE)
 
 
 def problem_raw(type, status, title, detail=None, instance=None, headers={}):
@@ -21,18 +63,42 @@ def problem(type, status, title, detail=None, instance=None, headers={}):
 
 
 def languages_for_request():
-    return languages_from_accept(flask.request.accept_languages)
+    return languages_from_accept(request.accept_languages)
 
 
 def originating_ip():
-    """If there is an X-Forwarded-For header, use its value as the
-    originating IP address. Otherwise, use the address that originated
-    this request.
     """
-    address = None
-    header = 'X-Forwarded-For'
-    if header in flask.request.headers:
-        address = flask.request.headers[header]
-    if not address:
-        address = flask.request.remote_addr
-    return address
+    Attempt to derive the client's IPv4 address from the flask.request object.
+
+    Looks first at the X-Forwarded-For header, checking for multiple values
+    (which can happen with multiple layers of proxy server). If no valid, public
+    IP address is found there, looks at the request.remote_addr value.
+
+    If X-Forwarded-For contains more than one IP, we return the first public IP
+    since the proxy servers will almost certainly be appending their IP to the end.
+
+    If no valid, public IPv4 address is found in either location, returns None.
+    """
+    forwarded_for = request.headers.get('X-Forwarded-For', None)
+
+    if not forwarded_for and not request.remote_addr:
+        return None     # Nothing to go on from the request object
+
+    client_ip = None
+
+    if forwarded_for:
+        try:
+            fwd4_addresses = re.findall(IPV4_REGEX, forwarded_for)
+        except TypeError:   # whatever's in the header isn't a string/bytes-like object
+            pass
+
+        for ip in fwd4_addresses:
+            if is_public_ipv4_address(ip):
+                client_ip = ip
+                break
+
+    if not client_ip and request.remote_addr:
+        if is_public_ipv4_address(request.remote_addr):
+            client_ip = request.remote_addr
+
+    return client_ip

--- a/util/flask_util.py
+++ b/util/flask_util.py
@@ -8,14 +8,15 @@ from . import problem_detail
 from .language import languages_from_accept
 
 
-IPV4_REGEX = re.compile(r"""(?P<address>              # entire address, capturing
+IPV4_REGEX = re.compile(r"""(?<![0-9])                # Preceding character if any may not be numeric
+                            (?P<address>              # entire address, capturing
                             (?:                       # quads 1-3 and separator, non-capturing
                                 (?:                   # quad value, non-capturing
-                                    25[0-5]       |   # triple digit 250-255
-                                    2[0-4][0-9]   |   # triple digit 200-249
-                                    1[0-9]{2}     |   # triple digit 100-199
+                                    [0-9]         |   # single digit   0-9
                                     [1-9][0-9]    |   # double digit  10-99
-                                    [0-9]             # single digit   0-9
+                                    1[0-9]{2}     |   # triple digit 100-199
+                                    2[0-4][0-9]   |   # triple digit 200-249
+                                    25[0-5]           # triple digit 250-255
                                 )\.                   # dot separator
                             ){3}
                             (?:                       # quad 4, non-capturing
@@ -26,6 +27,7 @@ IPV4_REGEX = re.compile(r"""(?P<address>              # entire address, capturin
                                 [0-9]                 # single digit   0-9
                             )
                           )
+                          (?![0-9])                   # trailing character if any may not be numeric
                           """, re.VERBOSE)
 
 


### PR DESCRIPTION
Previously a call to `flask_util.originating_ip()` would trigger an unhandled exception if the value in the `X-Forwarded-For` header contained more than a single IP address, which can happen when behind multiple layers of proxy server.

This makes `originating_ip()` more resilient to different values in `X-Forwarded-For` and the `request.remote_addr` property. It also explicitly restricts to publicly routable IP addresses, so we don't try to pass (for instance) a CIDR block IP into a geolocation-by-ip call.

I also had to fix some tests in `test_util_string_helpers.py` that were still using `nose`.