### PR TITLE
Provide service area information as part of a library's OPDS 2 entry

### DIFF
--- a/model.py
+++ b/model.py
@@ -211,6 +211,31 @@ def create(db, model, create_method='',
 
 Base = declarative_base()
 
+class LibraryType(object):
+    """Constant container for library types.
+
+    This is as defined here:
+
+    https://github.com/NYPL-Simplified/Simplified/wiki/LibraryRegistryPublicAPI#the-subject-scheme-for-library-types
+    """
+
+    SCHEME_URI = "http://librarysimplified.org/terms/library-types"
+    LOCAL = "local"
+    COUNTY = "county"
+    STATE = "state"
+    PROVINCE = "province"
+    NATIONAL = "national"
+    UNIVERSAL = "universal"
+
+    # Different nations use different terms for referring to their
+    # administrative divisions, which translates into different terms in
+    # the library type vocabulary.
+    ADMINISTRATIVE_DIVISION_TYPES = {
+        "US": STATE,
+        "CA" : PROVINCE,
+    }
+
+
 class Library(Base):
     """An entry in this table corresponds more or less to an OPDS server.
 
@@ -439,6 +464,58 @@ class Library(Base):
         return self.library_stage == prod and self.registry_stage == prod
 
     @property
+    def types(self):
+        """Return any special types for this library.
+
+        :yield: A sequence of strings.
+        """
+        service_area = self.service_area
+        if not service_area:
+            return
+        yield service_area.library_type
+
+        # TODO: more types, e.g. audience-based, can go here.
+
+    @property
+    def service_area(self):
+        """Return the service area of this Library, assuming there is only
+        one.
+
+        :return: A Place, if there is one well-defined place this
+        library serves; otherwise None.
+        """
+        everywhere = None
+
+        # Group the ServiceAreas by type.
+        by_type = defaultdict(set)
+        for a in self.service_areas:
+            if not a.place:
+                continue
+            if a.place.type == Place.EVERYWHERE:
+                # We will only return 'everywhere' if we don't find
+                # something more specific.
+                everywhere = a.place
+                continue
+            by_type[a.type].add(a)
+
+        # If there is a single focus area, use it.
+        # Otherwise, if there is a single eligibility area, use that.
+        service_area = None
+        for area_type in ServiceArea.FOCUS, ServiceArea.ELIGIBILITY:
+            if len(by_type[area_type]) == 1:
+                [service_area] = by_type[area_type]
+                if service_area.place:
+                    return service_area.place
+
+        # This library serves everywhere, and it doesn't _also_ serve
+        # some more specific place.
+        if everywhere:
+            return everywhere
+
+        # This library does not have one ServiceArea that stands out.
+        return None
+
+    @property
     def service_area_name(self):
         """Describe the library's service area in a short string a human would
         understand, e.g. "Kern County, CA".
@@ -454,31 +531,15 @@ class Library(Base):
         :return: A string, or None if the library's service area can't be
            described as a short string.
         """
-        # Group the ServiceAreas by type.
-        by_type = defaultdict(set)
-        for a in self.service_areas:
-            if not a.place:
-                continue
-            if a.place.type == Place.EVERYWHERE:
-                # We already know that 'everywhere' won't work. Ignore
-                # it so it doesn't mask something more specific.
-                continue
-            by_type[a.type].add(a)
+        service_area_place = self.service_area
+        if not service_area_place:
+            # There is no one place representing this library's service area.
+            return None
+        if service_area_place.type == Place.EVERYWHERE:
+            # "Everywhere" isn't a place with a well-known name.
+            return None
 
-        # If there is a single focus area, use it.
-        # Otherwise, if there is a single eligibility area, use that.
-        service_area = None
-        for area_type in ServiceArea.FOCUS, ServiceArea.ELIGIBILITY:
-            if len(by_type[area_type]) == 1:
-                [service_area] = by_type[area_type]
-                break
-
-        if service_area:
-            return service_area.place.human_friendly_name
-
-        # This library does not have one ServiceArea that stands out,
-        # so we can't describe its service area with a short string.
-        return None            
+        return service_area_place.human_friendly_name
 
     @classmethod
     def _feed_restriction(cls, production, library_field=None, registry_field=None):
@@ -1103,7 +1164,8 @@ class Place(Base):
     # supposed to be precise terms. Each census-designated place is
     # called a 'city', even if it's not a city in the legal sense.
     # Countries that call their top-level administrative divisions something
-    # other than 'states' can still use 'state' as their type.
+    # other than 'states' can still use 'state' as their type. (But see
+    # LibraryType.ADMINISTRATIVE_DIVISION_TYPES.)
     NATION = 'nation'
     STATE = 'state'
     COUNTY = 'county'
@@ -1296,6 +1358,30 @@ class Place(Base):
            of the list.
         """
         return [x.strip() for x in reversed(name.split(",")) if x.strip()]
+
+    @property
+    def library_type(self):
+        """If a library serves this place, what type of library does that make
+        it?
+
+        :return: A string; one of the constants from LibraryType.
+        """
+        if self.type == Place.EVERYWHERE:
+            return LibraryType.UNIVERSAL
+        if self.type == Place.NATION:
+            return LibraryType.NATIONAL
+        if self.type == Place.STATE:
+            # Whether this is a 'state' library, 'province' library,
+            # etc. depends on which nation it's in.
+            library_type = LibraryType.STATE
+            if self.parent and self.parent.type == Place.NATION:
+                library_type = LibraryType.ADMINISTRATIVE_DIVISION_TYPES.get(
+                    self.parent.abbreviated_name, library_type
+                )
+            return library_type
+        if self.type == Place.COUNTY:
+            return LibraryType.COUNTY
+        return LibraryType.LOCAL
 
     @property
     def human_friendly_name(self):

--- a/model.py
+++ b/model.py
@@ -542,15 +542,9 @@ class Library(Base):
         :return: A string, or None if the library's service area can't be
            described as a short string.
         """
-        service_area_place = self.service_area
-        if not service_area_place:
-            # There is no one place representing this library's service area.
-            return None
-        if service_area_place.type == Place.EVERYWHERE:
-            # "Everywhere" isn't a place with a well-known name.
-            return None
-
-        return service_area_place.human_friendly_name
+        if self.service_area:
+            return self.service_area.human_friendly_name
+        return None
 
     @classmethod
     def _feed_restriction(cls, production, library_field=None, registry_field=None):
@@ -1379,9 +1373,9 @@ class Place(Base):
         """
         if self.type == Place.EVERYWHERE:
             return LibraryType.UNIVERSAL
-        if self.type == Place.NATION:
+        elif self.type == Place.NATION:
             return LibraryType.NATIONAL
-        if self.type == Place.STATE:
+        elif self.type == Place.STATE:
             # Whether this is a 'state' library, 'province' library,
             # etc. depends on which nation it's in.
             library_type = LibraryType.STATE
@@ -1390,7 +1384,7 @@ class Place(Base):
                     self.parent.abbreviated_name, library_type
                 )
             return library_type
-        if self.type == Place.COUNTY:
+        elif self.type == Place.COUNTY:
             return LibraryType.COUNTY
         return LibraryType.LOCAL
 

--- a/model.py
+++ b/model.py
@@ -235,6 +235,14 @@ class LibraryType(object):
         "CA" : PROVINCE,
     }
 
+    NAME_FOR_CODE = {
+        LOCAL: "Local library",
+        COUNTY: "County library",
+        STATE: "State library",
+        PROVINCE: "Provincial library",
+        NATIONAL: "National library",
+        UNIVERSAL: "Online library",
+    }
 
 class Library(Base):
     """An entry in this table corresponds more or less to an OPDS server.
@@ -467,14 +475,17 @@ class Library(Base):
     def types(self):
         """Return any special types for this library.
 
-        :yield: A sequence of strings.
+        :yield: A sequence of code constants from LibraryTypes.
         """
         service_area = self.service_area
         if not service_area:
             return
-        yield service_area.library_type
+        code = service_area.library_type
+        if code:
+            yield code
 
-        # TODO: more types, e.g. audience-based, can go here.
+        # TODO: in the future, more types, e.g. audience-based, can go
+        # here.
 
     @property
     def service_area(self):

--- a/opds.py
+++ b/opds.py
@@ -6,6 +6,7 @@ from sqlalchemy.orm import Query
 from model import (
     ConfigurationSetting,
     Hyperlink,
+    LibraryType,
     Session,
     Validation,
 )
@@ -153,6 +154,16 @@ class OPDSCatalog(object):
 
         if library.description:
             metadata["description"] = library.description
+
+        subjects = []
+        for code in library.types:
+            subjects.append(
+                dict(code=code, name=LibraryType.NAME_FOR_CODE[code],
+                     scheme=LibraryType.SCHEME_URI)
+            )
+        if subjects:
+            metadata['subject'] = subjects
+
         catalog = dict(metadata=metadata)
 
         if library.opds_url:

--- a/opds.py
+++ b/opds.py
@@ -68,7 +68,12 @@ class OPDSCatalog(object):
 
         # To save bandwidth, omit logos from large feeds. What 'large'
         # means is customizable.
-        include_logos = not (self._feed_is_large(_db, libraries))
+        #
+        # To save time, omit service area information from large feeds
+        # which we know won't use it.
+        include_logos = include_service_areas = not (
+            self._feed_is_large(_db, libraries)
+        )
         self.catalog = dict(metadata=dict(title=title), catalogs=[])
 
         self.add_link_to_catalog(self.catalog, rel="self",
@@ -83,7 +88,8 @@ class OPDSCatalog(object):
                 self.library_catalog(
                     *library, url_for=url_for,
                     include_logo=include_logos,
-                    web_client_uri_template=web_client_uri_template
+                    web_client_uri_template=web_client_uri_template,
+                    include_service_area=include_service_areas
                 )
             )
         annotator.annotate_catalog(self, live=live)
@@ -116,7 +122,8 @@ class OPDSCatalog(object):
             include_private_information=False,
             include_logo=True,
             url_for=None,
-            web_client_uri_template=None
+            web_client_uri_template=None,
+            include_service_area=False,
     ):
 
         """Create an OPDS catalog for a library.
@@ -131,6 +138,11 @@ class OPDSCatalog(object):
         contact for integration problems will be included, where it
         normally wouldn't be.
 
+        :param include_service_area: If this is True, the
+            consumer of this OPDS catalog will be using information about
+            the library's service area. TODO: This can be removed
+            once we stop using the endpoints that just give a huge
+            list of libraries.
         """
         url_for = url_for or flask.url_for
 
@@ -148,21 +160,22 @@ class OPDSCatalog(object):
             for key in 'schema:distance', 'distance':
                 metadata[key] = value
 
-        service_area_name = library.service_area_name
-        if service_area_name is not None:
-            metadata['schema:areaServed'] = service_area_name
-
         if library.description:
             metadata["description"] = library.description
 
-        subjects = []
-        for code in library.types:
-            subjects.append(
-                dict(code=code, name=LibraryType.NAME_FOR_CODE[code],
-                     scheme=LibraryType.SCHEME_URI)
-            )
-        if subjects:
-            metadata['subject'] = subjects
+        if include_service_area:
+            service_area_name = library.service_area_name
+            if service_area_name is not None:
+                metadata['schema:areaServed'] = service_area_name
+
+            subjects = []
+            for code in library.types:
+                subjects.append(
+                    dict(code=code, name=LibraryType.NAME_FOR_CODE[code],
+                         scheme=LibraryType.SCHEME_URI)
+                )
+            if subjects:
+                metadata['subject'] = subjects
 
         catalog = dict(metadata=metadata)
 


### PR DESCRIPTION
This branch adds information about a library's service area to its OPDS 2 entry. This means the _name_ of the service area (e.g. "New York, NY") and an OPDS 2 category based on the _type_ of place the library covers (e.g. "local" or "state"). Together, these changes take care of https://jira.nypl.org/browse/SIMPLY-3660.

Two additional notes:

* Like logo images, service area information is omitted for large feeds such as the huge ones at /libraries. This guarantees that any additional performance impact of looking up service area information isn't multiplied 300-fold, killing performance on SimplyE.
* I changed a couple of metadata keys to be compliant with the OPDS spec: 'updated' became 'modified' and 'distance' became 'schema:distance'. These aren't used by SimplyE AFAIK but I made the changes backwards-compatible just in case.