### PR TITLE
Including uszipcode simple database in repo

### DIFF
--- a/config.py
+++ b/config.py
@@ -3,6 +3,8 @@ import copy
 import json
 import os
 import logging
+from pathlib import Path
+
 
 @contextlib.contextmanager
 def temp_config(new_config=None, replacement_classes=None):
@@ -18,10 +20,13 @@ def temp_config(new_config=None, replacement_classes=None):
         for c in replacement_classes:
             c.instance = old_config
 
+
 class CannotLoadConfiguration(Exception):
     pass
 
+
 class Configuration(object):
+    DATADIR = Path(os.path.dirname(__file__)) / 'data'
 
     instance = None
 

--- a/model.py
+++ b/model.py
@@ -1552,7 +1552,10 @@ class Place(Base):
             return None
 
         _db = Session.object_session(self)
-        search = uszipcode.SearchEngine(simple_zipcode=True)
+        search = uszipcode.SearchEngine(
+            db_file_dir=Configuration.DATADIR,
+            simple_zipcode=True
+        )
         state = self.abbreviated_name
         uszipcode_matches = []
         if (state in search.state_to_city_mapper


### PR DESCRIPTION
The test suite was failing because `uszipcode` wasn't able to pull down its simple db file due to a problem on datahub.io. I'm including the 9M file in `data/` so that doesn't happen. The pip version for `uszipcode` is pegged to 0.2.4, so I don't see this being a problem unless we need to upgrade.