### PR TITLE
Get Adobe endpoints to use utf8 decoded input

### DIFF
--- a/adobe_vendor_id.py
+++ b/adobe_vendor_id.py
@@ -32,7 +32,7 @@ class AdobeVendorIDController:
         """Process an incoming signInRequest document."""
         __transaction = self._db.begin_nested()
         output = self.request_handler.handle_signin_request(
-            request.data,
+            request.data.decode('utf8'),
             self.model.standard_lookup,
             self.model.authdata_lookup
         )
@@ -43,7 +43,7 @@ class AdobeVendorIDController:
     def userinfo_handler(self):
         """Process an incoming userInfoRequest document."""
         output = self.request_handler.handle_accountinfo_request(
-            request.data,
+            request.data.decode('utf8'),
             self.model.urn_to_label
         )
         return Response(output, 200, {"Content-Type": "application/xml"})

--- a/adobe_vendor_id.py
+++ b/adobe_vendor_id.py
@@ -1,26 +1,21 @@
-import datetime
 import flask
 from flask import Response
 
-import base64
 import re
 import requests
 
-from model import (
-    ShortClientTokenDecoder,
-)
+from model import ShortClientTokenDecoder
 
 from util.string_helpers import base64
 from util.xmlparser import XMLParser
 
 
 class AdobeVendorIDController(object):
-
-    """Flask controllers that implement the Account Service and
-    Authorization Service portions of the Adobe Vendor ID protocol.
     """
-    def __init__(self, _db, vendor_id, node_value,
-                 delegates=[]):
+    Flask controllers that implement the Account Service and Authorization Service
+    portions of the Adobe Vendor ID protocol.
+    """
+    def __init__(self, _db, vendor_id, node_value, delegates=None):
         """Constructor.
 
         :param delegates: A list of URLs or AdobeVendorIDClient
@@ -28,6 +23,9 @@ class AdobeVendorIDController(object):
         login, it will delegate to each of these other servers in
         turn.
         """
+        if not delegates:
+            delegates = []
+
         self._db = _db
         self.request_handler = AdobeVendorIDRequestHandler(vendor_id)
         self.model = AdobeVendorIDModel(self._db, node_value, delegates)
@@ -36,15 +34,20 @@ class AdobeVendorIDController(object):
         """Process an incoming signInRequest document."""
         __transaction = self._db.begin_nested()
         output = self.request_handler.handle_signin_request(
-            flask.request.data, self.model.standard_lookup,
-            self.model.authdata_lookup)
+            flask.request.data,
+            self.model.standard_lookup,
+            self.model.authdata_lookup
+        )
         __transaction.commit()
+
         return Response(output, 200, {"Content-Type": "application/xml"})
 
     def userinfo_handler(self):
         """Process an incoming userInfoRequest document."""
         output = self.request_handler.handle_accountinfo_request(
-            flask.request.data, self.model.urn_to_label)
+            flask.request.data,
+            self.model.urn_to_label
+        )
         return Response(output, 200, {"Content-Type": "application/xml"})
 
     def status_handler(self):
@@ -53,25 +56,26 @@ class AdobeVendorIDController(object):
 
 class AdobeRequestParser(XMLParser):
 
-    NAMESPACES = { "adept" : "http://ns.adobe.com/adept" }
+    NAMESPACES = {"adept": "http://ns.adobe.com/adept"}
 
     def process(self, data):
-        requests = list(self.process_all(
-            data, self.REQUEST_XPATH, self.NAMESPACES))
+        requests = list(self.process_all(data, self.REQUEST_XPATH, self.NAMESPACES))
+
         if not requests:
             return None
-        # There should only be one request tag, but if there's more than
-        # one, only return the first one.
-        return requests[0]
+
+        return requests[0]  # Return only the first request tag, even if there are multiple
 
     def _add(self, d, tag, key, namespaces, transform=None):
         v = self._xpath1(tag, 'adept:' + key, namespaces)
+
         if v is not None:
             v = v.text
             if v is not None:
                 v = v.strip()
-                if transform is not None:
+                if callable(transform):
                     v = transform(v)
+
         d[key] = v
 
 
@@ -87,14 +91,17 @@ class AdobeSignInRequestParser(AdobeRequestParser):
 
         if not method:
             raise ValueError("No signin method specified")
+
         data = dict(method=method)
+
         if method == self.STANDARD:
             self._add(data, tag, 'username', namespaces)
             self._add(data, tag, 'password', namespaces)
         elif method == self.AUTH_DATA:
             self._add(data, tag, self.AUTH_DATA, namespaces, base64.b64decode)
         else:
-            raise ValueError("Unknown signin method: %s" % method)
+            raise ValueError(f"Unknown signin method: {method}")
+
         return data
 
 
@@ -110,10 +117,7 @@ class AdobeAccountInfoRequestParser(AdobeRequestParser):
 
 
 class AdobeVendorIDRequestHandler(object):
-
-    """Standalone class that can be tested without bringing in Flask or
-    the database schema.
-    """
+    """Standalone class that can be tested without bringing in Flask or the database schema"""
 
     SIGN_IN_RESPONSE_TEMPLATE = """<signInResponse xmlns="http://ns.adobe.com/adept">
 <user>%(user)s</user>
@@ -138,120 +142,111 @@ class AdobeVendorIDRequestHandler(object):
 
     def handle_signin_request(self, data, standard_lookup, authdata_lookup):
         parser = AdobeSignInRequestParser()
+
         try:
             data = parser.process(data)
         except Exception as e:
             return self.error_document(self.AUTH_ERROR_TYPE, str(e))
+
         user_id = label = None
+
         if not data:
-            return self.error_document(
-                self.AUTH_ERROR_TYPE, "Request document in wrong format.")
-        if not 'method' in data:
-            return self.error_document(
-                self.AUTH_ERROR_TYPE, "No method specified")
+            return self.error_document(self.AUTH_ERROR_TYPE, "Request document in wrong format.")
+
+        if 'method' not in data:
+            return self.error_document(self.AUTH_ERROR_TYPE, "No method specified")
+
         if data['method'] == parser.STANDARD:
-            user_id, label = standard_lookup(data)
+            (user_id, label) = standard_lookup(data)
             failure = self.AUTHENTICATION_FAILURE
         elif data['method'] == parser.AUTH_DATA:
             authdata = data[parser.AUTH_DATA]
-            user_id, label = authdata_lookup(authdata)
+            (user_id, label) = authdata_lookup(authdata)
             failure = self.TOKEN_FAILURE
+
         if user_id is None:
             return self.error_document(self.AUTH_ERROR_TYPE, failure)
         else:
-            return self.SIGN_IN_RESPONSE_TEMPLATE % dict(
-                user=user_id, label=label)
+            return self.SIGN_IN_RESPONSE_TEMPLATE % {"user": user_id, "label": label}
 
     def handle_accountinfo_request(self, data, urn_to_label):
         parser = AdobeAccountInfoRequestParser()
         label = None
+
         try:
             data = parser.process(data)
             if not data:
-                return self.error_document(
-                    self.ACCOUNT_INFO_ERROR_TYPE,
-                    "Request document in wrong format.")
-            if not 'user' in data:
-                return self.error_document(
-                    self.ACCOUNT_INFO_ERROR_TYPE,
-                    "Could not find user identifer in request document.")
+                return self.error_document(self.ACCOUNT_INFO_ERROR_TYPE, "Request document in wrong format.")
+
+            if 'user' not in data:
+                return self.error_document(self.ACCOUNT_INFO_ERROR_TYPE,
+                                           "Could not find user identifer in request document.")
+
             label = urn_to_label(data['user'])
         except Exception as e:
-            return self.error_document(
-                self.ACCOUNT_INFO_ERROR_TYPE, str(e))
+            return self.error_document(self.ACCOUNT_INFO_ERROR_TYPE, str(e))
 
         if label:
             return self.ACCOUNT_INFO_RESPONSE_TEMPLATE % dict(label=label)
         else:
-            return self.error_document(
-                self.ACCOUNT_INFO_ERROR_TYPE,
-                self.URN_LOOKUP_FAILURE % data['user']
-            )
+            return self.error_document(self.ACCOUNT_INFO_ERROR_TYPE, self.URN_LOOKUP_FAILURE % data['user'])
 
     def error_document(self, type, message):
-        return self.ERROR_RESPONSE_TEMPLATE % dict(
-            vendor_id=self.vendor_id, type=type, message=message)
+        return self.ERROR_RESPONSE_TEMPLATE % {"vendor_id": self.vendor_id, "type": type, "message": message}
 
-class AdobeVendorIDModel(object):
 
-    """Implement Adobe Vendor ID within the library registry's database
-    model.
-    """
+class AdobeVendorIDModel:
+    """Implement Adobe Vendor ID within the library registry's database model"""
 
     def __init__(self, _db, node_value, delegates):
         self._db = _db
-
         delegate_objs = []
+
         for i in delegates:
             if isinstance(i, str):
                 delegate_objs.append(AdobeVendorIDClient(i))
             else:
                 delegate_objs.append(i)
-        self.short_client_token_decoder = ShortClientTokenDecoder(
-            node_value, delegate_objs
-        )
+
+        self.short_client_token_decoder = ShortClientTokenDecoder(node_value, delegate_objs)
 
     def standard_lookup(self, authorization_data):
-        """Treat an incoming username and password as the two parts of a short
-        client token. Return an Adobe Account ID and a human-readable
-        label. Create a DelegatedPatronIdentifier to hold the Adobe
-        Account ID if necessary.
+        """
+        Treat an incoming username and password as the two parts of a short client token.
+        Return an Adobe Account ID and a human-readable label. Create a DelegatedPatronIdentifier
+        to hold the Adobe Account ID if necessary.
         """
         username = authorization_data.get('username')
         password = authorization_data.get('password')
+
         try:
             delegated_patron_identifier = self.short_client_token_decoder.decode_two_part(
                 self._db, username, password
             )
-        except ValueError as e:
+        except ValueError:
             delegated_patron_identifier = None
+
         if delegated_patron_identifier:
             return self.account_id_and_label(delegated_patron_identifier)
         else:
             for delegate in self.short_client_token_decoder.delegates:
                 try:
-                    account_id, label, content = delegate.sign_in_standard(
-                        username, password
-                    )
+                    (account_id, label, _) = delegate.sign_in_standard(username, password)
                     return account_id, label
-                except Exception as e:
-                    # This delegate couldn't help us.
-                    pass
+                except Exception:
+                    pass        # This delegate couldn't help us.
 
-        # Neither this server nor the delegates were able to do anything.
-        return None, None
+        return (None, None)   # Neither this server nor the delegates were able to do anything.
 
     def authdata_lookup(self, authdata):
-        """Treat an authdata string as a short client token. Return an Adobe
-        Account ID and a human-readable label. Create a
-        DelegatedPatronIdentifier to hold the Adobe Account ID if
-        necessary.
+        """
+        Treat an authdata string as a short client token. Return an Adobe Account ID and a
+        human-readable label. Create a DelegatedPatronIdentifier to hold the Adobe Account ID
+        if necessary.
         """
         try:
-            delegated_patron_identifier = self.short_client_token_decoder.decode(
-                self._db, authdata
-            )
-        except ValueError as e:
+            delegated_patron_identifier = self.short_client_token_decoder.decode(self._db, authdata)
+        except ValueError:
             delegated_patron_identifier = None
 
         if delegated_patron_identifier:
@@ -259,28 +254,24 @@ class AdobeVendorIDModel(object):
         else:
             for delegate in self.short_client_token_decoder.delegates:
                 try:
-                    account_id, label, content = delegate.sign_in_authdata(
-                        authdata
-                    )
+                    (account_id, label, _) = delegate.sign_in_authdata(authdata)
                     return account_id, label
-                except Exception as e:
-                    # This delegate couldn't help us.
-                    pass
+                except Exception:
+                    pass    # This delegate couldn't help us.
 
-        # Neither this server nor the delegates were able to do anything.
-        # We couldn't find anything.
-        return None, None
+        return (None, None)  # Neither this server nor the delegates were able to do anything.
 
     def account_id_and_label(self, delegated_patron_identifier):
-        "Turn a DelegatedPatronIdentifier into a (account id, label) 2-tuple."
+        """Turn a DelegatedPatronIdentifier into a 2-tuple of (account id, label)"""
         if not delegated_patron_identifier:
             return (None, None)
+
         urn = delegated_patron_identifier.delegated_identifier
         return (urn, self.urn_to_label(urn))
 
     def urn_to_label(self, urn):
         """We have no information about patrons, so labels are sparse."""
-        return "Delegated account ID %s" % urn
+        return f"Delegated account ID {urn}"
 
 
 class VendorIDAuthenticationError(Exception):
@@ -291,17 +282,15 @@ class VendorIDServerException(Exception):
     """The Vendor ID service is not working properly."""
 
 
-class AdobeVendorIDClient(object):
-    """A client library for the Adobe Vendor ID protocol.
+class AdobeVendorIDClient:
+    """
+    A client library for the Adobe Vendor ID protocol.
 
-    This is used by the AdobeVendorIDAcceptanceTestScript to verify
-    the compliance of the library registry.
+    Used by the AdobeVendorIDAcceptanceTestScript to verify the compliance of the library registry.
 
-    It may also be used during a transition period where you are
-    moving from another Vendor ID implementation to a library
-    registry. You can delegate to another Vendor ID implementation the
-    validation of any credentials that cannot be validated through the
-    library registry.
+    It may also be used during a transition period where you are moving from another Vendor ID
+    implementation to a library registry. You can delegate to another Vendor ID implementation the
+    validation of any credentials that cannot be validated through the library registry.
     """
 
     SIGNIN_AUTHDATA_BODY = """<signInRequest method="authData" xmlns="http://ns.adobe.com/adept">
@@ -370,10 +359,10 @@ class AdobeVendorIDClient(object):
 
     def handle_error(self, status_code, content):
         if status_code != 200:
-            raise VendorIDServerException(
-                "Unexpected status code: %s" % status_code
-            )
+            raise VendorIDServerException(f"Unexpected status code: {status_code}")
+
         error = self._extract_by_re(content, self.ERROR_RE)
+
         if error:
             raise VendorIDAuthenticationError(error)
 
@@ -388,8 +377,10 @@ class AdobeVendorIDClient(object):
         self.handle_error(response.status_code, content)
         identifier = self.extract_user_identifier(content)
         label = self.extract_label(content)
+
         if not identifier or not label:
             raise VendorIDServerException("Unexpected response: %s" % content)
+
         return identifier, label, content
 
 
@@ -404,15 +395,15 @@ class MockAdobeVendorIDClient(AdobeVendorIDClient):
         self.queue.insert(0, response)
 
     def dequeue(self, *args, **kwargs):
-        """Dequeue a response.
-
-        If it's an exception, raise it. Otherwise return it.
-        """
+        """Dequeue a response. If it's an exception, raise it. Otherwise return it."""
         if not self.queue:
             raise VendorIDServerException("No response queued.")
+
         response = self.queue.pop()
+
         if isinstance(response, Exception):
             raise response
+
         return response
 
     status = dequeue

--- a/adobe_xml_templates.py
+++ b/adobe_xml_templates.py
@@ -1,0 +1,23 @@
+ACCOUNT_INFO_REQUEST_TEMPLATE = """<accountInfoRequest method="standard" xmlns="http://ns.adobe.com/adept">
+<user>%(uuid)s</user>
+</accountInfoRequest >"""
+
+ACCOUNT_INFO_RESPONSE_TEMPLATE = """<accountInfoResponse xmlns="http://ns.adobe.com/adept">
+    <label>%(label)s</label>
+</accountInfoResponse>"""
+
+ERROR_RESPONSE_TEMPLATE = '<error xmlns="http://ns.adobe.com/adept" data="E_%(vendor_id)s_%(type)s %(message)s"/>'
+
+AUTHDATA_SIGN_IN_REQUEST_TEMPLATE = """<signInRequest method="authData" xmlns="http://ns.adobe.com/adept">
+<authData>%(authdata)s</authData>
+</signInRequest>"""
+
+SIGN_IN_REQUEST_TEMPLATE = """<signInRequest method="standard" xmlns="http://ns.adobe.com/adept">
+    <username>%(username)s</username>
+    <password>%(password)s</password>
+</signInRequest>"""
+
+SIGN_IN_RESPONSE_TEMPLATE = """<signInResponse xmlns="http://ns.adobe.com/adept">
+    <user>%(user)s</user>
+    <label>%(label)s</label>
+</signInResponse>"""

--- a/app.py
+++ b/app.py
@@ -3,7 +3,7 @@ import os
 import sys
 import urllib.parse
 
-from flask import Flask, url_for, redirect, Response, request
+from flask import Flask, Response
 from flask_babel import Babel
 from flask_sqlalchemy_session import flask_scoped_session
 
@@ -47,30 +47,35 @@ else:
     if getattr(app, 'library_registry', None) is None:
         app.library_registry = LibraryRegistry(_db)
 
+
 @app.before_first_request
 def set_secret_key(_db=None):
     _db = _db or app._db
     app.secret_key = ConfigurationSetting.sitewide_secret(_db, Configuration.SECRET_KEY)
+
 
 @app.teardown_request
 def shutdown_session(exception):
     """Commit or rollback the database session associated with
     the request.
     """
-    if (hasattr(app, 'library_registry',)
-        and hasattr(app.library_registry, '_db')
-        and app.library_registry._db
+    if (
+        hasattr(app, 'library_registry',) and
+        hasattr(app.library_registry, '_db') and
+        app.library_registry._db
     ):
         if exception:
             app.library_registry._db.rollback()
         else:
             app.library_registry._db.commit()
 
+
 @app.route('/')
 @uses_location
 @returns_problem_detail
 def nearby(_location):
     return app.library_registry.registry_controller.nearby(_location)
+
 
 @app.route('/qa')
 @uses_location
@@ -80,16 +85,19 @@ def nearby_qa(_location):
         _location, live=False
     )
 
-@app.route("/register", methods=["GET","POST"])
+
+@app.route("/register", methods=["GET", "POST"])
 @returns_problem_detail
 def register():
     return app.library_registry.registry_controller.register()
+
 
 @app.route('/search')
 @uses_location
 @returns_problem_detail
 def search(_location):
     return app.library_registry.registry_controller.search(_location)
+
 
 @app.route('/qa/search')
 @uses_location
@@ -99,12 +107,14 @@ def search_qa(_location):
         _location, live=False
     )
 
+
 @app.route('/confirm/<int:resource_id>/<secret>')
 @returns_problem_detail
 def confirm_resource(resource_id, secret):
     return app.library_registry.validation_controller.confirm(
         resource_id, secret
     )
+
 
 @app.route('/libraries')
 @compressible
@@ -113,6 +123,7 @@ def confirm_resource(resource_id, secret):
 def libraries_opds(_location=None):
     return app.library_registry.registry_controller.libraries_opds(location=_location)
 
+
 @app.route('/libraries/qa')
 @compressible
 @uses_location
@@ -120,50 +131,60 @@ def libraries_opds(_location=None):
 def libraries_qa(_location=None):
     return app.library_registry.registry_controller.libraries_opds(location=_location, live=False)
 
+
 @app.route('/admin/log_in', methods=["POST"])
 @returns_problem_detail
 def log_in():
     return app.library_registry.registry_controller.log_in()
+
 
 @app.route('/admin/log_out')
 @returns_problem_detail
 def log_out():
     return app.library_registry.registry_controller.log_out()
 
+
 @app.route('/admin/libraries')
 @returns_json_or_response_or_problem_detail
 def libraries():
     return app.library_registry.registry_controller.libraries()
+
 
 @app.route('/admin/libraries/qa')
 @returns_json_or_response_or_problem_detail
 def libraries_qa_admin():
     return app.library_registry.registry_controller.libraries(live=False)
 
+
 @app.route('/admin/libraries/<uuid>')
 @returns_json_or_response_or_problem_detail
 def library_details(uuid):
     return app.library_registry.registry_controller.library_details(uuid)
+
 
 @app.route('/admin/libraries/search_details', methods=["POST"])
 @returns_json_or_response_or_problem_detail
 def search_details():
     return app.library_registry.registry_controller.search_details()
 
+
 @app.route('/admin/libraries/email', methods=["POST"])
 @returns_json_or_response_or_problem_detail
 def validate_email():
     return app.library_registry.registry_controller.validate_email()
+
 
 @app.route('/admin/libraries/registration', methods=["POST"])
 @returns_json_or_response_or_problem_detail
 def edit_registration():
     return app.library_registry.registry_controller.edit_registration()
 
+
 @app.route('/admin/libraries/pls_id', methods=["POST"])
 @returns_json_or_response_or_problem_detail
 def pls_id():
     return app.library_registry.registry_controller.add_or_edit_pls_id()
+
 
 @app.route('/library/<uuid>')
 @has_library
@@ -171,17 +192,20 @@ def pls_id():
 def library():
     return app.library_registry.registry_controller.library()
 
+
 @app.route('/library/<uuid>/eligibility')
 @has_library
 @returns_problem_detail
 def library_eligibility():
     return app.library_registry.coverage_controller.eligibility_for_library()
 
+
 @app.route('/library/<uuid>/focus')
 @has_library
 @returns_problem_detail
 def library_focus():
     return app.library_registry.coverage_controller.focus_for_library()
+
 
 @app.route('/coverage')
 @returns_problem_detail
@@ -194,6 +218,7 @@ def coverage():
 def hearbeat():
     return app.library_registry.heartbeat.heartbeat()
 
+
 # Adobe Vendor ID implementation
 @app.route('/AdobeAuth/SignIn', methods=['POST'])
 @returns_problem_detail
@@ -203,6 +228,7 @@ def adobe_vendor_id_signin():
     else:
         return Response("", 404)
 
+
 @app.route('/AdobeAuth/AccountInfo', methods=['POST'])
 @returns_problem_detail
 def adobe_vendor_id_accountinfo():
@@ -210,6 +236,7 @@ def adobe_vendor_id_accountinfo():
         return app.library_registry.adobe_vendor_id.userinfo_handler()
     else:
         return Response("", 404)
+
 
 @app.route('/AdobeAuth/Status')
 @returns_problem_detail

--- a/app.py
+++ b/app.py
@@ -56,9 +56,7 @@ def set_secret_key(_db=None):
 
 @app.teardown_request
 def shutdown_session(exception):
-    """Commit or rollback the database session associated with
-    the request.
-    """
+    """Commit or rollback the database session associated with the request."""
     if (
         hasattr(app, 'library_registry',) and
         hasattr(app.library_registry, '_db') and
@@ -81,9 +79,7 @@ def nearby(_location):
 @uses_location
 @returns_problem_detail
 def nearby_qa(_location):
-    return app.library_registry.registry_controller.nearby(
-        _location, live=False
-    )
+    return app.library_registry.registry_controller.nearby(_location, live=False)
 
 
 @app.route("/register", methods=["GET", "POST"])
@@ -103,17 +99,13 @@ def search(_location):
 @uses_location
 @returns_problem_detail
 def search_qa(_location):
-    return app.library_registry.registry_controller.search(
-        _location, live=False
-    )
+    return app.library_registry.registry_controller.search(_location, live=False)
 
 
 @app.route('/confirm/<int:resource_id>/<secret>')
 @returns_problem_detail
 def confirm_resource(resource_id, secret):
-    return app.library_registry.validation_controller.confirm(
-        resource_id, secret
-    )
+    return app.library_registry.validation_controller.confirm(resource_id, secret)
 
 
 @app.route('/libraries')

--- a/util/xmlparser.py
+++ b/util/xmlparser.py
@@ -1,17 +1,51 @@
 from lxml import etree
 from io import StringIO
 
-class XMLParser(object):
 
+class XMLParser:
     """Helper functions to process XML data."""
-
+    ##### Class Constants ####################################################  # noqa: E266
     NAMESPACES = {}
 
+    ##### Public Interface / Magic Methods ###################################  # noqa: E266
+    def process_all(self, xml, xpath, namespaces=None, handler=None, parser=None):
+        if not parser:
+            parser = etree.XMLParser()
+
+        if not handler:
+            handler = self.process_one
+
+        if isinstance(xml, str):
+            root = etree.parse(StringIO(xml), parser)
+        else:
+            root = xml
+
+        for i in root.xpath(xpath, namespaces=namespaces):
+            data = handler(i, namespaces)
+            if data:
+                yield data
+
+    def process_one(self, tag, namespaces):
+        """Abstract, should be overridden by child class"""
+        return None
+
+    ##### Private Methods ####################################################  # noqa: E266
+    def _cls(self, tag_name, class_name):
+        """Return an XPath expression that will find a tag with the given CSS class."""
+        fmt_string = 'descendant-or-self::node()/%s[contains(concat(" ", normalize-space(@class), " "), " %s ")]'
+        return fmt_string % (tag_name, class_name)
+
+    ##### Properties and Getters/Setters #####################################  # noqa: E266
+
+    ##### Class Methods ######################################################  # noqa: E266
+
+    ##### Private Class Methods ##############################################  # noqa: E266
     @classmethod
     def _xpath(cls, tag, expression, namespaces=None):
+        """Wrapper to do a namespaced XPath expression."""
         if not namespaces:
             namespaces = cls.NAMESPACES
-        """Wrapper to do a namespaced XPath expression."""
+
         return tag.xpath(expression, namespaces=namespaces)
 
     @classmethod
@@ -20,44 +54,5 @@ class XMLParser(object):
         values = cls._xpath(tag, expression, namespaces=namespaces)
         if not values:
             return None
+
         return values[0]
-
-    def _cls(self, tag_name, class_name):
-        """Return an XPath expression that will find a tag with the given CSS class."""
-        return 'descendant-or-self::node()/%s[contains(concat(" ", normalize-space(@class), " "), " %s ")]' % (tag_name, class_name)
-
-    def text_of_optional_subtag(self, tag, name, namespaces=None):
-        tag = self._xpath1(tag, name, namespaces=namespaces)
-        if tag is None or tag.text is None:
-            return None
-        else:
-            return str(tag.text)
-      
-    def text_of_subtag(self, tag, name, namespaces=None):
-        return str(tag.xpath(name, namespaces=namespaces)[0].text)
-
-    def int_of_subtag(self, tag, name, namespaces=None):
-        return int(self.text_of_subtag(tag, name, namespaces=namespaces))
-
-    def int_of_optional_subtag(self, tag, name, namespaces=None):
-        v = self.text_of_optional_subtag(tag, name, namespaces=namespaces)
-        if not v:
-            return v
-        return int(v)
-
-    def process_all(self, xml, xpath, namespaces=None, handler=None, parser=None):
-        if not parser:
-            parser = etree.XMLParser()
-        if not handler:
-            handler = self.process_one
-        if isinstance(xml, str):
-            root = etree.parse(StringIO(xml), parser)
-        else:
-            root = xml
-        for i in root.xpath(xpath, namespaces=namespaces):
-            data = handler(i, namespaces)
-            if data:
-                yield data
-
-    def process_one(self, tag, namespaces):
-        return None


### PR DESCRIPTION
As per [SIMPLY-3744](https://jira.nypl.org/browse/SIMPLY-3744), the py3 registry in QA was failing to successfully complete the Adobe sign in loop, and was returning the following error:

```xml
<error xmlns="http://ns.adobe.com/adept" data="E_NYPL_AUTH 'bytes' object has no attribute 'xpath'"/>
```

This changeset makes the Adobe endpoints for sign in and user info read in from `flask.request.data.decode('utf8')` instead of just `flask.request.data`, which is a bytestring (and not able to be parsed by the adobe request parser).

Unfortunately our tests in `test_adobe_vendor_id.py` would not have caught this, because they don't engage the actual flask request/response cycle. I'm not reconfiguring to add those tests in this PR because it would slow things down quite a lot, but I will add a TODO item to make sure they're testable in future.