### PR TITLE
Use 'libreg_active' instead of 'libreg_prod' for clarity

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,8 @@
 ##############################################################################
 # This is a multi-stage Dockerfile with three targets:
 #   * libreg_local_db
-#   * webapp_dev
-#   * webapp_prod
+#   * libreg_local
+#   * libreg_active
 # 
 # For background on multi-stage builds, see:
 #
@@ -165,12 +165,12 @@ ENTRYPOINT ["/bin/sh", "-c", "/docker-entrypoint.sh"]
 
 
 ##############################################################################
-# Build target: libreg_dev
+# Build target: libreg_local
 # 
 # Note that this target assumes a host mount is in place to link the current
 # directory into the container at /simplye_app. The production target copies in
 # the entire project directory since it will remain static.
-FROM builder AS libreg_dev
+FROM builder AS libreg_local
 
 ENV FLASK_ENV development
 ENV SIMPLYE_RUN_WEBPACK_WATCH 1
@@ -181,9 +181,9 @@ RUN apk add --no-cache npm
 
 
 ##############################################################################
-# Build target: libreg_prod
+# Build target: libreg_active
 #
-FROM builder AS libreg_prod
+FROM builder AS libreg_active
 
 ENV FLASK_ENV production
 

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: help build db-session webapp-shell up up-watch start stop down test clean full-clean build-prod up-prod up-prod-watch test-prod down-prod
+.PHONY: help build db-session webapp-shell up up-watch start stop down test clean full-clean build-active up-active up-active-watch test-active down-active
 .DEFAULT_GOAL := help
 
 help:
@@ -6,22 +6,27 @@ help:
 	@echo ""
 	@echo "Commands:"
 	@echo ""
-	@echo "    build          - Build the libreg_webapp and libreg_local_db images"
-	@echo "    db-session     - Start a psql session as the superuser on the db container"
-	@echo "    webapp-shell   - Open a shell on the webapp container"
-	@echo "    up             - Bring up the local cluster in detached mode"
-	@echo "    up-watch       - Bring up the local cluster, remains attached"
-	@echo "    start          - Start a stopped cluster"
-	@echo "    stop           - Stop the cluster without removing containers"
-	@echo "    down           - Take down the local cluster"
-	@echo "    test           - Run the python test suite on the webapp container"
-	@echo "    clean          - Take down the local cluster and removes the db volume"
-	@echo "    full-clean     - Take down the local cluster and remove containers, volumes, and images"
-	@echo "    build-prod     - Build images based on the docker-compose-cicd.yml file"
-	@echo "    up-prod        - Bring up the cluster from the docker-compose-cicd.yml file"
-	@echo "    up-prod-watch  - Bring up the cluster from the cicd file, stay attached"
-	@echo "    test-prod      - Run the test suite on the prod container"
-	@echo "    down-prod      - Stop the cluster from the cicd file"
+	@echo "  Related to Local Development:"
+	@echo ""
+	@echo "    build            - Build the libreg_webapp and libreg_local_db images"
+	@echo "    db-session       - Start a psql session as the superuser on the db container"
+	@echo "    webapp-shell     - Open a shell on the webapp container"
+	@echo "    up               - Bring up the local cluster in detached mode"
+	@echo "    up-watch         - Bring up the local cluster, remains attached"
+	@echo "    start            - Start a stopped cluster"
+	@echo "    stop             - Stop the cluster without removing containers"
+	@echo "    down             - Take down the local cluster"
+	@echo "    test             - Run the python test suite on the webapp container"
+	@echo "    clean            - Take down the local cluster and removes the db volume"
+	@echo "    full-clean       - Take down the local cluster and remove containers, volumes, and images"
+	@echo ""
+	@echo "  Related to Deployment:"
+	@echo ""
+	@echo "    build-active     - Build images based on the docker-compose-cicd.yml file"
+	@echo "    up-active        - Bring up the cluster from the docker-compose-cicd.yml file"
+	@echo "    up-active-watch  - Bring up the cluster from the cicd file, stay attached"
+	@echo "    test-active      - Run the test suite on the local libreg_active_webapp container"
+	@echo "    down-active      - Stop the cluster from the cicd file"
 
 build:
 	docker-compose build
@@ -56,17 +61,17 @@ clean:
 full-clean:
 	docker-compose down --volumes --rmi all
 
-build-prod:
+build-active:
 	docker-compose -f docker-compose-cicd.yml build
 
-up-prod:
+up-active:
 	docker-compose -f docker-compose-cicd.yml up -d
 
-up-prod-watch:
+up-active-watch:
 	docker-compose -f docker-compose-cicd.yml up
 
-test-prod:
-	docker exec -it libreg_prod_webapp pipenv run pytest tests
+test-active:
+	docker exec -it libreg_active_webapp pipenv run pytest tests
 
-down-prod:
+down-active:
 	docker-compose -f docker-compose-cicd.yml down

--- a/docker-compose-cicd.yml
+++ b/docker-compose-cicd.yml
@@ -9,13 +9,13 @@ services:
     volumes:
       - local_db_data:/var/lib/postgresql/data
 
-  libreg_prod_webapp:
-    container_name: libreg_prod_webapp
+  libreg_active_webapp:
+    container_name: libreg_active_webapp
     depends_on: 
       - libreg_test_db
     build:
       context: .
-      target: libreg_prod
+      target: libreg_active
       labels:
         - "com.nypl.docker.imagename=library_registry"
     environment:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -19,7 +19,7 @@ services:
       - libreg_local_db
     build:
       context: .
-      target: libreg_dev
+      target: libreg_local
     ports:
       - "80:80"
     environment:


### PR DESCRIPTION
Purely changing the name conventions here, to make build and deploy work clearer. Previously I'd labeled a bunch of stuff based on the string `libreg_prod`, but that encompassed both QA and prod image builds, so I decided (with a little help) to switch to `libreg_active`.