### PR TITLE
Updates registry_admin version number + CHANGELOG

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 ## CHANGELOG
 
+### v1.0.11
+
+#### Updated
+
+- Updated the Registry Admin version to v1.4.15.
+
 ### v1.0.10
 
 #### Updated

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "library_registry",
-  "version": "1.0.10",
+  "version": "1.0.11",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1185,9 +1185,9 @@
       }
     },
     "library-simplified-reusable-components": {
-      "version": "1.3.19",
-      "resolved": "https://registry.npmjs.org/library-simplified-reusable-components/-/library-simplified-reusable-components-1.3.19.tgz",
-      "integrity": "sha512-4IcGK+PT8hl5YVUex9vCXRAGRXShYZt7F5uG21CMsFGIUsD6neROD+gdoOhU6wJQqjpuagnISEa/A4imhRVFww==",
+      "version": "1.3.20",
+      "resolved": "https://registry.npmjs.org/library-simplified-reusable-components/-/library-simplified-reusable-components-1.3.20.tgz",
+      "integrity": "sha512-YiuyaQH+171T/SBS6AWCz3etvx4sOwXwWuYiMP1kMcriHZmoww+dTcR4fLxQ0SshxG9w+LGqAQlGc0XpPuPTGg==",
       "requires": {
         "@nypl/dgx-svg-icons": "^0.3.9",
         "react": "^16.8.6",
@@ -2111,9 +2111,9 @@
       }
     },
     "redux": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/redux/-/redux-4.1.0.tgz",
-      "integrity": "sha512-uI2dQN43zqLWCt6B/BMGRMY6db7TTY4qeHHfGeKb3EOhmOKjU3KdWvNLJyqaHRksv/ErdNH7cFZWg9jXtewy4g==",
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/redux/-/redux-4.1.1.tgz",
+      "integrity": "sha512-hZQZdDEM25UY2P493kPYuKqviVwZ58lEmGQNeQ+gXa+U0gYPUBf7NKYazbe3m+bs/DzM/ahN12DbF+NG8i0CWw==",
       "requires": {
         "@babel/runtime": "^7.9.2"
       }
@@ -2309,13 +2309,13 @@
       "integrity": "sha512-VUJ49FC8U1OxwZLxIbTTrDvLnf/6TDgxZcK8wxR8zs13xpx7xbG60ndBlhNrFi2EMuFRoeDoJO7wthSLq42EjA=="
     },
     "simplified-registry-admin": {
-      "version": "1.4.14",
-      "resolved": "https://registry.npmjs.org/simplified-registry-admin/-/simplified-registry-admin-1.4.14.tgz",
-      "integrity": "sha512-L+JTr+lVbrl6sgnRGZxXHpuvEjQW4C04+p4ZfPt8fCY2WDpqKtRhPjX8CiPGc68VHBYnuu2CMVWdcJosRBaZbg==",
+      "version": "1.4.15",
+      "resolved": "https://registry.npmjs.org/simplified-registry-admin/-/simplified-registry-admin-1.4.15.tgz",
+      "integrity": "sha512-GCY3DUyT0P8D8xpoqTEvoDZpDkkxqNfLC9LaJ3kjJwgsQ6xLRDBZCji+Ajzb0S3Q0YDfNHU5Ld1G2i0nJcSpIA==",
       "requires": {
         "@nypl/dgx-svg-icons": "^0.3.13",
         "bootstrap": "^3.3.6",
-        "library-simplified-reusable-components": "^1.3.19",
+        "library-simplified-reusable-components": "^1.3.20",
         "node-sass": "^4.14.1",
         "opds-web-client": "0.3.4",
         "prop-types": "^15.7.2",

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   "author": "NYPL",
   "license": "Apache-2.0",
   "dependencies": {
-    "simplified-registry-admin": "1.4.14"
+    "simplified-registry-admin": "1.4.15"
   },
   "homepage": "https://github.com/NYPL-Simplified/library_registry#readme"
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "library_registry",
-  "version": "1.0.10",
+  "version": "1.0.11",
   "description": "Library Registry Admin Interface",
   "main": "index.js",
   "repository": {


### PR DESCRIPTION
**Change**
- Updated registry_admin version number from v1.4.14 to v1.4.15.

**Reason**
- Updated the SearchForm component in the registry_admin to display a loading message before the search is completed. Need to update the version in the library_registry to deploy this new feature to QA.