### PR TITLE
SIMPLY-3870: Adding hostname to SMTP object instantiation

### DIFF
--- a/emailer.py
+++ b/emailer.py
@@ -133,7 +133,7 @@ class Emailer:
     ##### Private Methods ####################################################  # noqa: E266
     def _send_email(self, to_address, body, smtp=None):
         """Actually send an email."""
-        smtp = smtp or smtplib.SMTP()
+        smtp = smtp or smtplib.SMTP(self.smtp_host)
         smtp.connect(self.smtp_host, self.smtp_port)
         smtp.starttls()
         smtp.login(self.smtp_username, self.smtp_password)


### PR DESCRIPTION
Notification emails were failing to send, with:

```
Error handling request /register
Traceback (most recent call last):

[...]

  File "/simplye_app/app.py", line 88, in register
    return app.library_registry.registry_controller.register()
  File "/simplye_app/controller.py", line 647, in register
    hyperlink.notify(self.emailer, self.app.url_for)
  File "/simplye_app/model.py", line 1822, in notify
    body = emailer.send(email_type, to_address, **template_args)
  File "/simplye_app/emailer.py", line 186, in send
    return self._send_email(to_address, body, smtp)
  File "/simplye_app/emailer.py", line 192, in _send_email
    smtp.starttls()
  File "/usr/local/lib/python3.9/smtplib.py", line 774, in starttls
    self.sock = context.wrap_socket(self.sock,
  File "/usr/local/lib/python3.9/ssl.py", line 500, in wrap_socket
    return self.sslsocket_class._create(
  File "/usr/local/lib/python3.9/ssl.py", line 1031, in _create
    self._sslobj = self._context._wrap_socket(
ValueError: server_hostname cannot be an empty string or start with a leading dot.
```

Which is indicative of the bug mentioned [in this StackOverflow thread](https://stackoverflow.com/questions/51768041/python3-smtp-valueerror-server-hostname-cannot-be-an-empty-string-or-start-with), where you have to provide the hostname to the `SMTP()` object during instantiation. I've added that argument and tested the connection by script, and it gets past the error successfully.