### PR TITLE
SIMPLIFIED_TEST_DB env var shouldn't need to be set in remote envs

### DIFF
--- a/library_registry/app.py
+++ b/library_registry/app.py
@@ -24,7 +24,6 @@ TESTING = 'TESTING' in os.environ
 babel = Babel()
 
 db_url = Configuration.database_url(test=TESTING)
-test_db_url = Configuration.database_url(test=True)
 
 
 def create_app(testing=False, db_session_obj=None):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -8,7 +8,8 @@ from sqlalchemy import create_engine
 from sqlalchemy.exc import ProgrammingError
 from sqlalchemy.orm.session import Session
 
-from library_registry.app import create_app, test_db_url
+from library_registry.app import create_app
+from library_registry.config import Configuration
 from library_registry.model import (
     Admin,
     Audience,
@@ -27,6 +28,7 @@ from library_registry.model_helpers import get_one_or_create
 from library_registry.util import GeometryUtility
 
 TEST_DATA_DIR = Path(os.path.dirname(__file__)) / "data"
+test_db_url = Configuration.database_url(test=True)
 
 
 def pytest_configure(config):


### PR DESCRIPTION
IT let me know that the QA registry instance was flailing after they made a change to the ECS task definition. They had changed the name of the db string env var from `SIMPLIFIED_PRODUCTION_DATABASE` to `SIMPLIFIED_TEST_DATABASE`, and since the webapp depends on finding a usable connection string in `SIMPLIFIED_PRODUCTION_DATABASE` to successfully start up, it was exiting prematurely.

Unfortunately just changing the name back was insufficient, because it turned out `app.py` was also depending on having a value set for `SIMPLIFIED_TEST_DATABASE` as well. That's not actually necessary in that file--it was only there to be imported to the pytest `conftest.py` file. I've moved the call over to `conftest.py` directly, which allows the webapp to start even if the test db env var is undefined.