### PR TITLE
Erd 26 security fix add authentication check to admin apis

### DIFF
--- a/library_registry/admin/decorators.py
+++ b/library_registry/admin/decorators.py
@@ -1,0 +1,13 @@
+from flask import session
+from functools import wraps
+from library_registry.problem_details import (
+    INVALID_CREDENTIALS,
+)
+
+def check_logged_in(fn):
+    @wraps(fn)
+    def decorated(*args, **kwargs):
+        if not session.get("username"):
+            return INVALID_CREDENTIALS.response # 401 Unauthorized, username or password is incorrect
+        return fn(*args, **kwargs)
+    return decorated

--- a/library_registry/admin/routes.py
+++ b/library_registry/admin/routes.py
@@ -1,5 +1,5 @@
 from flask import Blueprint, current_app
-from . import controller
+from library_registry.admin.decorators import check_logged_in
 
 from library_registry.decorators import (
     returns_json_or_response_or_problem_detail,
@@ -20,41 +20,49 @@ def log_in():
     return current_app.library_registry.admin_controller.log_in()
 
 @admin.route('/admin/log_out')
+@check_logged_in
 @returns_problem_detail
 def log_out():
     return current_app.library_registry.admin_controller.log_out()
 
 @admin.route('/admin/libraries')
+@check_logged_in
 @returns_json_or_response_or_problem_detail
 def libraries():
     return current_app.library_registry.admin_controller.libraries()
 
 @admin.route('/admin/libraries/qa')
+@check_logged_in
 @returns_json_or_response_or_problem_detail
 def libraries_qa_admin():
     return current_app.library_registry.admin_controller.libraries(live=False)
 
 @admin.route('/admin/libraries/<uuid>')
+@check_logged_in
 @returns_json_or_response_or_problem_detail
 def library_details(uuid):
     return current_app.library_registry.admin_controller.library_details(uuid)
 
 @admin.route('/admin/libraries/search_details', methods=["POST"])
+@check_logged_in
 @returns_json_or_response_or_problem_detail
 def search_details():
     return current_app.library_registry.admin_controller.search_details()
 
 @admin.route('/admin/libraries/email', methods=["POST"])
+@check_logged_in
 @returns_json_or_response_or_problem_detail
 def validate_email():
     return current_app.library_registry.admin_controller.validate_email()
 
 @admin.route('/admin/libraries/registration', methods=["POST"])
+@check_logged_in
 @returns_json_or_response_or_problem_detail
 def edit_registration():
     return current_app.library_registry.admin_controller.edit_registration()
 
 @admin.route('/admin/libraries/pls_id', methods=["POST"])
+@check_logged_in
 @returns_json_or_response_or_problem_detail
 def pls_id():
     return current_app.library_registry.admin_controller.add_or_edit_pls_id()


### PR DESCRIPTION
## Description

This work is for bug [ERD-26](https://jira.nypl.org/browse/ERD-26).

This PR:

- Creates a decorator in library_registry/admin/decorators.py to check if a user has been assigned a session cookie. If the user has not, then INVALID_CREDENTIALS (from library_registry/problem_details.py) is returned, which is a 401 with an incorrect credentials message. 
- Decorates the relevant admin routes to require that a user be authenticated and, if not, receive a 401 status code.

## Motivation and Context

Most admin routes did not check for authentication. This was not entirely terrible since any accessible information was already public, and it did not appear that the secret between the registry and circulation manager could be obtained. However, this still isn't a good practice, and it is important to shore this up, particularly as we move forward with improving authentication in general.

## How Has This Been Tested?

Set up a local environment following these [local development instructions](https://github.com/NYPL-Simplified/library_registry/blob/develop/docs/Development.md).

Test using the **Makefile** in the root of the repository and the **make test** command. All tests passed locally. Specifically, in test_controllers.py in TestAdminController, there are tests for various authentication scenarios.

## Checklist:

- [ ] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
