### PR TITLE
Jwt log in and refresh

### DIFF
--- a/library_registry/admin/controller.py
+++ b/library_registry/admin/controller.py
@@ -64,12 +64,13 @@ class AdminController(BaseController):
             return INVALID_CREDENTIALS
 
     def refresh_token(self):
-        if verify_jwt_in_request():
-            identity = get_jwt_identity()
-            access_token = create_access_token(identity=identity)
-            response = Response(201)
-            set_access_cookies(response, access_token)
-            return response
+        if not verify_jwt_in_request(refresh=True):
+            return
+        identity = get_jwt_identity()
+        access_token = create_access_token(identity=identity)
+        response = Response([], 201)
+        set_access_cookies(response, access_token)
+        return response
 
     def log_out(self):
         session["username"] = ""

--- a/library_registry/admin/controller.py
+++ b/library_registry/admin/controller.py
@@ -79,9 +79,6 @@ class AdminController(BaseController):
         if not verify_jwt_in_request(optional=True):
             session["username"] = ""
             return Response(200)
-        response = Response(200)
-        unset_jwt_cookies(response)
-        return response
 
     def refresh_token(self):
         """Refresh JWT access tokens

--- a/library_registry/admin/controller.py
+++ b/library_registry/admin/controller.py
@@ -1,8 +1,8 @@
 from flask import (Response, render_template_string,
-                   session, redirect, request, url_for, make_response)
+                   session, redirect, request, url_for, make_response, jsonify)
 
 from flask_jwt_extended import (create_access_token,
-                                verify_jwt_in_request, get_jwt_identity, set_access_cookies, unset_jwt_cookies)
+                                verify_jwt_in_request, get_jwt_identity, unset_jwt_cookies, create_refresh_token)
 
 from sqlalchemy.orm import (defer, joinedload)
 from library_registry.admin.templates.templates import admin as admin_template
@@ -63,11 +63,11 @@ class AdminController(BaseController):
             return INVALID_CREDENTIALS
         if not jwt_cookie_boolean:
             session["username"] = username
-            return redirect(url_for('admin.admin_view'))
+            return Response(200)
         access_token = create_access_token(identity=username)
-        response = make_response(redirect(url_for('admin.admin_view')), 302)
-        set_access_cookies(response, access_token)
-        return response
+        refresh_token = create_refresh_token(identity=username)
+        return jsonify(access_token=access_token,
+                       refresh_token=refresh_token)
 
     def log_out(self):
         """End point for both Flask Session logout and Flask JWT Logout

--- a/library_registry/admin/controller.py
+++ b/library_registry/admin/controller.py
@@ -40,7 +40,7 @@ class AdminController(BaseController):
         super(AdminController, self).__init__(app)
         self.emailer = emailer_class
 
-    def log_in(self):
+    def log_in(self, jwt_preferred=False):
         """End point for login with requesting flask sessions or JWT tokens
 
         Returns:
@@ -50,10 +50,9 @@ class AdminController(BaseController):
         """
         username = request.form.get("username")
         password = request.form.get("password")
-        jwt = request.form.get('jwt')
         if not Admin.authenticate(self._db, username, password):
             return INVALID_CREDENTIALS
-        if not jwt:
+        if not jwt_preferred:
             session["username"] = username
             return redirect(url_for('admin.admin_view'))
         access_token = create_access_token(identity=username)

--- a/library_registry/admin/controller.py
+++ b/library_registry/admin/controller.py
@@ -1,8 +1,8 @@
 from flask import (Response, render_template_string,
-                   session, redirect, request, url_for, make_response, jsonify)
+                   session, request, jsonify)
 
 from flask_jwt_extended import (create_access_token,
-                                verify_jwt_in_request, get_jwt_identity, unset_jwt_cookies, create_refresh_token)
+                                verify_jwt_in_request, get_jwt_identity, create_refresh_token)
 
 from sqlalchemy.orm import (defer, joinedload)
 from library_registry.admin.templates.templates import admin as admin_template

--- a/library_registry/admin/controller.py
+++ b/library_registry/admin/controller.py
@@ -83,6 +83,13 @@ class AdminController(BaseController):
         unset_jwt_cookies(response)
         return response
 
+    def refresh(self):
+        if not verify_jwt_in_request(optional=True):
+            return INVALID_CREDENTIALS
+        identity = get_jwt_identity()
+        access_token = create_access_token(identity=identity)
+        return jsonify(access_token=access_token)
+
     def libraries(self, live=True):
         # Return a specific set of information about all libraries in production;
         # this generates the library list in the admin interface.

--- a/library_registry/admin/controller.py
+++ b/library_registry/admin/controller.py
@@ -1,5 +1,5 @@
 from flask import (Response, render_template_string,
-                   session, request, jsonify)
+                   session, request, jsonify, redirect, url_for)
 
 from flask_jwt_extended import (create_access_token,
                                 verify_jwt_in_request, get_jwt_identity, create_refresh_token)
@@ -63,7 +63,7 @@ class AdminController(BaseController):
             return INVALID_CREDENTIALS
         if not jwt_cookie_boolean:
             session["username"] = username
-            return Response(200)
+            return redirect(url_for('admin.admin_view'))
         access_token = create_access_token(identity=username)
         refresh_token = create_refresh_token(identity=username)
         return jsonify(access_token=access_token,
@@ -78,7 +78,7 @@ class AdminController(BaseController):
         """
         if not verify_jwt_in_request(optional=True):
             session["username"] = ""
-            return Response(200)
+            return redirect(url_for('admin.admin_view'))
 
     def refresh_token(self):
         """Refresh JWT access tokens

--- a/library_registry/admin/controller.py
+++ b/library_registry/admin/controller.py
@@ -83,8 +83,8 @@ class AdminController(BaseController):
         unset_jwt_cookies(response)
         return response
 
-    def refresh(self):
-        if not verify_jwt_in_request(optional=True):
+    def refresh_token(self):
+        if not verify_jwt_in_request(optional=True, refresh=True):
             return INVALID_CREDENTIALS
         identity = get_jwt_identity()
         access_token = create_access_token(identity=identity)

--- a/library_registry/admin/controller.py
+++ b/library_registry/admin/controller.py
@@ -78,12 +78,20 @@ class AdminController(BaseController):
         """
         if not verify_jwt_in_request(optional=True):
             session["username"] = ""
-            return redirect(url_for('admin.admin_view'))
-        response = make_response(redirect(url_for('admin.admin_view')))
+            return Response(200)
+        response = Response(200)
         unset_jwt_cookies(response)
         return response
 
     def refresh_token(self):
+        """Refresh JWT access tokens
+
+        Expects JWT Refresh Token in request
+
+        Returns:
+            JWT: New JWT access token
+            Err: Invalid Credentials response
+        """
         if not verify_jwt_in_request(optional=True, refresh=True):
             return INVALID_CREDENTIALS
         identity = get_jwt_identity()

--- a/library_registry/admin/controller.py
+++ b/library_registry/admin/controller.py
@@ -63,9 +63,9 @@ class AdminController(BaseController):
             return INVALID_CREDENTIALS
         if not jwt_cookie_boolean:
             session["username"] = username
-            return [], 200
+            return redirect(url_for('admin.admin_view'))
         access_token = create_access_token(identity=username)
-        response = make_response([], 200)
+        response = make_response(redirect(url_for('admin.admin_view')), 302)
         set_access_cookies(response, access_token)
         return response
 

--- a/library_registry/admin/controller.py
+++ b/library_registry/admin/controller.py
@@ -26,10 +26,16 @@ from library_registry.model import (
 
 class ViewController(BaseController):
     def __call__(self):
+        """View controller for setting Flask Session or Flask JWT to verify user
+
+        Returns:
+            Response: rednered template string with user identity
+        """
         if verify_jwt_in_request(optional=True):
             username = get_jwt_identity()
         else:
             username = session.get('username', '')
+
         response = Response(render_template_string(
             admin_template,
             username=username

--- a/library_registry/admin/controller.py
+++ b/library_registry/admin/controller.py
@@ -346,5 +346,5 @@ class ValidationController(BaseController):
         validation.mark_as_successful()
 
         resource = validation.resource
-        message = _("You successfully confirmed %s.") % resource.href
+        message = ("You successfully confirmed %s.") % resource.href
         return self.html_response(200, message)

--- a/library_registry/admin/controller.py
+++ b/library_registry/admin/controller.py
@@ -49,7 +49,7 @@ class AdminController(BaseController):
         super(AdminController, self).__init__(app)
         self.emailer = emailer_class
 
-    def log_in(self, jwt_boolean=False):
+    def log_in(self, log_in_method):
         """End point for login with requesting flask sessions or JWT tokens
 
         Returns:
@@ -61,7 +61,7 @@ class AdminController(BaseController):
         password = request.form.get("password")
         if not Admin.authenticate(self._db, username, password):
             return INVALID_CREDENTIALS
-        if not jwt_boolean:
+        if not log_in_method:
             session["username"] = username
             return redirect(url_for('admin.admin_view'))
         access_token = create_access_token(identity=username)

--- a/library_registry/admin/controller.py
+++ b/library_registry/admin/controller.py
@@ -26,7 +26,10 @@ from library_registry.model import (
 
 class ViewController(BaseController):
     def __call__(self):
-        username = session.get('username', '')
+        if verify_jwt_in_request(optional=True):
+            username = get_jwt_identity()
+        else:
+            username = session.get('username', '')
         response = Response(render_template_string(
             admin_template,
             username=username

--- a/library_registry/admin/controller.py
+++ b/library_registry/admin/controller.py
@@ -49,7 +49,7 @@ class AdminController(BaseController):
         super(AdminController, self).__init__(app)
         self.emailer = emailer_class
 
-    def log_in(self, jwt_preferred=False):
+    def log_in(self, jwt_cookie_boolean=False):
         """End point for login with requesting flask sessions or JWT tokens
 
         Returns:
@@ -61,7 +61,7 @@ class AdminController(BaseController):
         password = request.form.get("password")
         if not Admin.authenticate(self._db, username, password):
             return INVALID_CREDENTIALS
-        if not jwt_preferred:
+        if not jwt_cookie_boolean:
             session["username"] = username
             return [], 200
         access_token = create_access_token(identity=username)

--- a/library_registry/admin/controller.py
+++ b/library_registry/admin/controller.py
@@ -49,7 +49,7 @@ class AdminController(BaseController):
         super(AdminController, self).__init__(app)
         self.emailer = emailer_class
 
-    def log_in(self, jwt_cookie_boolean=False):
+    def log_in(self, jwt_boolean=False):
         """End point for login with requesting flask sessions or JWT tokens
 
         Returns:
@@ -61,7 +61,7 @@ class AdminController(BaseController):
         password = request.form.get("password")
         if not Admin.authenticate(self._db, username, password):
             return INVALID_CREDENTIALS
-        if not jwt_cookie_boolean:
+        if not jwt_boolean:
             session["username"] = username
             return redirect(url_for('admin.admin_view'))
         access_token = create_access_token(identity=username)

--- a/library_registry/admin/controller.py
+++ b/library_registry/admin/controller.py
@@ -1,8 +1,8 @@
 from flask import (Response, render_template_string,
                    session, redirect, request, url_for, make_response)
 
-from flask_jwt_extended import (create_access_token, create_refresh_token,
-                                verify_jwt_in_request, get_jwt_identity, set_access_cookies, set_refresh_cookies, unset_jwt_cookies)
+from flask_jwt_extended import (create_access_token,
+                                verify_jwt_in_request, get_jwt_identity, set_access_cookies, unset_jwt_cookies)
 
 from sqlalchemy.orm import (defer, joinedload)
 from library_registry.admin.templates.templates import admin as admin_template
@@ -57,11 +57,9 @@ class AdminController(BaseController):
             session["username"] = username
             return redirect(url_for('admin.admin_view'))
         access_token = create_access_token(identity=username)
-        refresh_token = create_refresh_token(identity=username)
         response = make_response(
             redirect(url_for('admin.admin_view')), 302)
         set_access_cookies(response, access_token)
-        set_refresh_cookies(response, refresh_token)
         return response
 
     def log_out(self):

--- a/library_registry/admin/controller.py
+++ b/library_registry/admin/controller.py
@@ -61,7 +61,7 @@ class AdminController(BaseController):
         password = request.form.get("password")
         if not Admin.authenticate(self._db, username, password):
             return INVALID_CREDENTIALS
-        if not log_in_method:
+        if not log_in_method == 'jwt':
             session["username"] = username
             return redirect(url_for('admin.admin_view'))
         access_token = create_access_token(identity=username)

--- a/library_registry/admin/controller.py
+++ b/library_registry/admin/controller.py
@@ -63,10 +63,9 @@ class AdminController(BaseController):
             return INVALID_CREDENTIALS
         if not jwt_preferred:
             session["username"] = username
-            return redirect(url_for('admin.admin_view'))
+            return [], 200
         access_token = create_access_token(identity=username)
-        response = make_response(
-            redirect(url_for('admin.admin_view')), 302)
+        response = make_response([], 200)
         set_access_cookies(response, access_token)
         return response
 

--- a/library_registry/admin/decorators.py
+++ b/library_registry/admin/decorators.py
@@ -1,4 +1,5 @@
 from flask import session
+from flask_jwt_extended import verify_jwt_in_request
 from functools import wraps
 from library_registry.problem_details import (
     INVALID_CREDENTIALS,
@@ -8,8 +9,8 @@ from library_registry.problem_details import (
 def check_logged_in(fn):
     @wraps(fn)
     def decorated(*args, **kwargs):
-        if not session.get("username"):
+        if session.get("username") or verify_jwt_in_request(optional=True):
             # 401 Unauthorized, username or password is incorrect
-            return INVALID_CREDENTIALS.response
-        return fn(*args, **kwargs)
+            return fn(*args, **kwargs)
+        return INVALID_CREDENTIALS.response
     return decorated

--- a/library_registry/admin/decorators.py
+++ b/library_registry/admin/decorators.py
@@ -4,10 +4,12 @@ from library_registry.problem_details import (
     INVALID_CREDENTIALS,
 )
 
+
 def check_logged_in(fn):
     @wraps(fn)
     def decorated(*args, **kwargs):
         if not session.get("username"):
-            return INVALID_CREDENTIALS.response # 401 Unauthorized, username or password is incorrect
+            # 401 Unauthorized, username or password is incorrect
+            return INVALID_CREDENTIALS.response
         return fn(*args, **kwargs)
     return decorated

--- a/library_registry/admin/routes.py
+++ b/library_registry/admin/routes.py
@@ -25,7 +25,7 @@ def admin_view():
 def log_in(log_in_method):
     """Log in method using Flask Session or JWT Tokens
     ---
-    get:
+    post:
       tags:
         - authentication
       summary: Return Flask session or JWT Token if JWT boolean sent
@@ -43,10 +43,10 @@ def log_in(log_in_method):
             type: string
           description: Client Password
         - in: URL
-          name: jwt_cookie_boolean
-          description: Boolean to verify if client app is requesting JWT Token authorization
+          name: log_in_method
+          description: URL parameter string, any string will return JWT Token
           schema:
-            type: boolean
+            type: string
       responses:
         200:
             description: Successful authentication (Flask session)
@@ -77,7 +77,7 @@ def log_in(log_in_method):
 def refresh_token():
     """Refresh JWT access token method
     ---
-    get:
+    post:
       tags:
         - authentication
       summary: Return new JWT Access Token

--- a/library_registry/admin/routes.py
+++ b/library_registry/admin/routes.py
@@ -29,10 +29,10 @@ def log_in(jwt_cookie_boolean=False):
 
 # We are using the `refresh=True` options in jwt_required to only allow
 # refresh tokens to access this route.
-@admin.route("/admin/refresh", methods=["POST"])
+@admin.route("/admin/refresh_token", methods=["POST"])
 @jwt_required(refresh=True)
 def refresh():
-    return current_app.library_registry.admin_controller.refresh()
+    return current_app.library_registry.admin_controller.refresh_token()
 
 
 @admin.route('/admin/log_out')

--- a/library_registry/admin/routes.py
+++ b/library_registry/admin/routes.py
@@ -40,9 +40,10 @@ def admin_view():
 
 
 @admin.route('/admin/log_in', methods=["POST"])
+@admin.route('/admin/log_in/<jwt_preferred>')
 @returns_problem_detail
-def log_in():
-    return current_app.library_registry.admin_controller.log_in()
+def log_in(jwt_preferred=False):
+    return current_app.library_registry.admin_controller.log_in(jwt_preferred)
 
 
 @admin.route('/admin/log_out')

--- a/library_registry/admin/routes.py
+++ b/library_registry/admin/routes.py
@@ -24,6 +24,43 @@ def admin_view():
 @admin.route('/admin/log_in/<jwt_cookie_boolean>')
 @returns_problem_detail
 def log_in(jwt_cookie_boolean=False):
+    """Log in method using Flask Session or JWT Tokens
+    ---
+    get:
+      tags:
+        - authentication
+      summary: Return Flask session or JWT Token if JWT boolean sent
+      description: |
+        Authenticates a user usind the Admin Controller
+      parameters:
+        - in: form
+          name: username
+          schema:
+            type: string
+          description: Client Username
+        - in: form
+          name: password
+          schema:
+            type: string
+          description: Client Password
+        - in: URL
+          name: jwt_cookie_boolean
+          description: Boolean to verify if client app is requesting JWT Token authorization
+          schema:
+            type: boolean
+      responses:
+        200:
+            description: Successful authentication (Flask session)
+        200:
+            description: Returns JWT auth and refresh tokens
+        4XX:
+          description: |
+            An error including:
+            * `INVALID_CREDENTIALS`: Invalid username or password
+          content:
+            application/json:
+              schema: ProblemResponse 
+    """
     return current_app.library_registry.admin_controller.log_in(jwt_cookie_boolean)
 
 
@@ -31,7 +68,33 @@ def log_in(jwt_cookie_boolean=False):
 # refresh tokens to access this route.
 @admin.route("/admin/refresh_token", methods=["POST"])
 @jwt_required(refresh=True)
-def refresh():
+def refresh_token():
+    """Refresh JWT access token method
+    ---
+    get:
+      tags:
+        - authentication
+      summary: Return new JWT Access Token
+      description: |
+        Returns new JWT access token if there is a valid JWT Refresh Token in the request
+      parameters:
+        - in: request
+          name: jwt_refresh_token
+          schema:
+            type: jwt_token
+          description: A valid JWT refresh token
+
+      responses:
+        200:
+            description: Returns new JWT access token
+        4XX:
+          description: |
+            An error including:
+            * `INVALID_CREDENTIALS`: Invalid username or password
+          content:
+            application/json:
+              schema: ProblemResponse
+    """
     return current_app.library_registry.admin_controller.refresh_token()
 
 

--- a/library_registry/admin/routes.py
+++ b/library_registry/admin/routes.py
@@ -19,10 +19,10 @@ def admin_view():
     return current_app.library_registry.view_controller()
 
 
-@admin.route('/admin/log_in', methods=["POST"])
-@admin.route('/admin/log_in/<jwt_boolean>')
+@admin.route('/admin/log_in', methods=["POST"], defaults={'log_in_method': None})
+@admin.route('/admin/log_in/<log_in_method>', methods=["POST"])
 @returns_problem_detail
-def log_in(jwt_boolean=False):
+def log_in(log_in_method):
     """Log in method using Flask Session or JWT Tokens
     ---
     get:
@@ -67,7 +67,7 @@ def log_in(jwt_boolean=False):
             application/json:
               schema: ProblemResponse 
     """
-    return current_app.library_registry.admin_controller.log_in(jwt_boolean)
+    return current_app.library_registry.admin_controller.log_in(log_in_method)
 
 
 # We are using the `refresh=True` options in jwt_required to only allow

--- a/library_registry/admin/routes.py
+++ b/library_registry/admin/routes.py
@@ -1,7 +1,7 @@
 from datetime import datetime, timezone, timedelta
 from flask import Blueprint, current_app, make_response
 
-from flask_jwt_extended import jwt_required, get_jwt, create_access_token, get_jwt_identity, set_access_cookies
+from flask_jwt_extended import jwt_required, get_jwt, create_access_token, get_jwt_identity, set_access_cookies, verify_jwt_in_request
 
 from library_registry.admin.decorators import check_logged_in
 
@@ -19,6 +19,8 @@ admin = Blueprint(
 # minutes of expiring. Change the timedeltas to match the needs of your application.
 @admin.after_request
 def refresh_expiring_jwts(response):
+    if not verify_jwt_in_request(optional=True, locations='cookies'):
+        return response
     try:
         exp_timestamp = get_jwt()["exp"]
         now = datetime.now(timezone.utc)

--- a/library_registry/admin/routes.py
+++ b/library_registry/admin/routes.py
@@ -44,7 +44,7 @@ def log_in(jwt):
           description: Client Password
         - in: URL
           name: log_in_method
-          description: URL parameter string, any string will return JWT Token
+          description: URL parameter string, 'jwt' expected
           schema:
             type: string
       responses:

--- a/library_registry/admin/routes.py
+++ b/library_registry/admin/routes.py
@@ -41,10 +41,10 @@ def admin_view():
 
 
 @admin.route('/admin/log_in', methods=["POST"])
-@admin.route('/admin/log_in/<jwt_boolean>')
+@admin.route('/admin/log_in/<jwt_cookie_boolean>')
 @returns_problem_detail
-def log_in(jwt_boolean=False):
-    return current_app.library_registry.admin_controller.log_in(jwt_boolean)
+def log_in(jwt_cookie_boolean=False):
+    return current_app.library_registry.admin_controller.log_in(jwt_cookie_boolean)
 
 
 @admin.route('/admin/log_out')

--- a/library_registry/admin/routes.py
+++ b/library_registry/admin/routes.py
@@ -49,7 +49,6 @@ def log_in(jwt_preferred=False):
 @admin.route('/admin/log_out')
 @check_logged_in
 @returns_problem_detail
-@jwt_required(optional=True)
 def log_out():
     return current_app.library_registry.admin_controller.log_out()
 

--- a/library_registry/admin/routes.py
+++ b/library_registry/admin/routes.py
@@ -33,11 +33,11 @@ def log_in_w_token():
 
 # We are using the `refresh=True` options in jwt_required to only allow
 # refresh tokens to access this route.
-@admin.route('/admin/refresh', methods=['POST'])
+@admin.route('/admin/refresh_token', methods=['POST'])
 @returns_problem_detail
 @jwt_required(refresh=True)
-def refresh():
-    return current_app.library_registry.admin_controller.refresh()
+def refresh_token():
+    return current_app.library_registry.admin_controller.refresh_token()
 
 
 @admin.route('/admin/log_out')

--- a/library_registry/admin/routes.py
+++ b/library_registry/admin/routes.py
@@ -20,9 +20,9 @@ def admin_view():
 
 
 @admin.route('/admin/log_in', methods=["POST"])
-@admin.route('/admin/log_in/<jwt_cookie_boolean>')
+@admin.route('/admin/log_in/<jwt_boolean>')
 @returns_problem_detail
-def log_in(jwt_cookie_boolean=False):
+def log_in(jwt_boolean=False):
     """Log in method using Flask Session or JWT Tokens
     ---
     get:
@@ -67,7 +67,7 @@ def log_in(jwt_cookie_boolean=False):
             application/json:
               schema: ProblemResponse 
     """
-    return current_app.library_registry.admin_controller.log_in(jwt_cookie_boolean)
+    return current_app.library_registry.admin_controller.log_in(jwt_boolean)
 
 
 # We are using the `refresh=True` options in jwt_required to only allow

--- a/library_registry/admin/routes.py
+++ b/library_registry/admin/routes.py
@@ -1,4 +1,4 @@
-from flask import Blueprint, current_app, jsonify
+from flask import Blueprint, current_app
 
 from flask_jwt_extended import jwt_required
 
@@ -43,6 +43,7 @@ def refresh_token():
 @admin.route('/admin/log_out')
 @check_logged_in
 @returns_problem_detail
+@jwt_required(optional=True)
 def log_out():
     return current_app.library_registry.admin_controller.log_out()
 

--- a/library_registry/admin/routes.py
+++ b/library_registry/admin/routes.py
@@ -59,6 +59,13 @@ def log_in(jwt_cookie_boolean=False):
           content:
             application/json:
               schema: ProblemResponse 
+        5XX:
+          description: |
+            An error including:
+            * `INTERNAL_SERVER_ERROR`: Internal server error
+          content:
+            application/json:
+              schema: ProblemResponse 
     """
     return current_app.library_registry.admin_controller.log_in(jwt_cookie_boolean)
 
@@ -93,6 +100,13 @@ def refresh_token():
           content:
             application/json:
               schema: ProblemResponse
+        5XX:
+          description: |
+            An error including:
+            * `INTERNAL_SERVER_ERROR`: Internal server error
+          content:
+            application/json:
+              schema: ProblemResponse 
     """
     return current_app.library_registry.admin_controller.refresh_token()
 

--- a/library_registry/admin/routes.py
+++ b/library_registry/admin/routes.py
@@ -14,10 +14,9 @@ admin = Blueprint(
     'admin', __name__,
     template_folder='templates')
 
+
 # Using an `after_request` callback, we refresh any token that is within 30
 # minutes of expiring. Change the timedeltas to match the needs of your application.
-
-
 @admin.after_request
 def refresh_expiring_jwts(response):
     try:

--- a/library_registry/admin/routes.py
+++ b/library_registry/admin/routes.py
@@ -20,9 +20,9 @@ def admin_view():
 
 
 @admin.route('/admin/log_in', methods=["POST"], defaults={'log_in_method': None})
-@admin.route('/admin/log_in/<log_in_method>', methods=["POST"])
+@admin.route('/admin/log_in/<jwt>', methods=["POST"])
 @returns_problem_detail
-def log_in(log_in_method):
+def log_in(jwt):
     """Log in method using Flask Session or JWT Tokens
     ---
     post:
@@ -67,7 +67,7 @@ def log_in(log_in_method):
             application/json:
               schema: ProblemResponse 
     """
-    return current_app.library_registry.admin_controller.log_in(log_in_method)
+    return current_app.library_registry.admin_controller.log_in(jwt)
 
 
 # We are using the `refresh=True` options in jwt_required to only allow

--- a/library_registry/admin/routes.py
+++ b/library_registry/admin/routes.py
@@ -39,10 +39,10 @@ def admin_view():
 
 
 @admin.route('/admin/log_in', methods=["POST"])
-@admin.route('/admin/log_in/<jwt_preferred>')
+@admin.route('/admin/log_in/<jwt_boolean>')
 @returns_problem_detail
-def log_in(jwt_preferred=False):
-    return current_app.library_registry.admin_controller.log_in(jwt_preferred)
+def log_in(jwt_boolean=False):
+    return current_app.library_registry.admin_controller.log_in(jwt_boolean)
 
 
 @admin.route('/admin/log_out')

--- a/library_registry/admin/routes.py
+++ b/library_registry/admin/routes.py
@@ -119,7 +119,6 @@ def log_out():
 
 
 @admin.route('/admin/libraries')
-@jwt_required(optional=True)
 @check_logged_in
 @returns_json_or_response_or_problem_detail
 def libraries():

--- a/library_registry/admin/routes.py
+++ b/library_registry/admin/routes.py
@@ -1,7 +1,6 @@
-from datetime import datetime, timezone, timedelta
-from flask import Blueprint, current_app, make_response, jsonify
+from flask import Blueprint, current_app
 
-from flask_jwt_extended import jwt_required, get_jwt, create_access_token, get_jwt_identity, set_access_cookies, verify_jwt_in_request
+from flask_jwt_extended import jwt_required
 
 from library_registry.admin.decorators import check_logged_in
 

--- a/library_registry/admin/routes.py
+++ b/library_registry/admin/routes.py
@@ -15,26 +15,6 @@ admin = Blueprint(
     template_folder='templates')
 
 
-# Using an `after_request` callback, we refresh any token that is within 30
-# minutes of expiring. Change the timedeltas to match the needs of your application.
-@admin.after_request
-def refresh_expiring_jwts(response):
-    if not verify_jwt_in_request(optional=True, locations='cookies'):
-        return response
-    try:
-        exp_timestamp = get_jwt()["exp"]
-        now = datetime.now(timezone.utc)
-        target_timestamp = datetime.timestamp(now + timedelta(minutes=30))
-        if target_timestamp > exp_timestamp:
-            access_token = create_access_token(identity=get_jwt_identity())
-            response = make_response(response, 201)
-            set_access_cookies(response, access_token)
-        return response
-    except (RuntimeError, KeyError):
-        # Case where there is not a valid JWT. Just return the original response
-        return response
-
-
 @admin.route('/admin/', strict_slashes=False)
 def admin_view():
     return current_app.library_registry.view_controller()

--- a/library_registry/admin/routes.py
+++ b/library_registry/admin/routes.py
@@ -1,5 +1,5 @@
 from datetime import datetime, timezone, timedelta
-from flask import Blueprint, current_app, make_response
+from flask import Blueprint, current_app, make_response, jsonify
 
 from flask_jwt_extended import jwt_required, get_jwt, create_access_token, get_jwt_identity, set_access_cookies, verify_jwt_in_request
 
@@ -25,6 +25,14 @@ def admin_view():
 @returns_problem_detail
 def log_in(jwt_cookie_boolean=False):
     return current_app.library_registry.admin_controller.log_in(jwt_cookie_boolean)
+
+
+# We are using the `refresh=True` options in jwt_required to only allow
+# refresh tokens to access this route.
+@admin.route("/admin/refresh", methods=["POST"])
+@jwt_required(refresh=True)
+def refresh():
+    return current_app.library_registry.admin_controller.refresh()
 
 
 @admin.route('/admin/log_out')

--- a/library_registry/admin/routes.py
+++ b/library_registry/admin/routes.py
@@ -1,4 +1,7 @@
-from flask import Blueprint, current_app
+from flask import Blueprint, current_app, jsonify
+
+from flask_jwt_extended import jwt_required
+
 from library_registry.admin.decorators import check_logged_in
 
 from library_registry.decorators import (
@@ -10,14 +13,32 @@ admin = Blueprint(
     'admin', __name__,
     template_folder='templates')
 
+
 @admin.route('/admin/', strict_slashes=False)
 def admin_view():
     return current_app.library_registry.view_controller()
+
 
 @admin.route('/admin/log_in', methods=["POST"])
 @returns_problem_detail
 def log_in():
     return current_app.library_registry.admin_controller.log_in()
+
+
+@admin.route('/admin/log_in_w_token', methods=['POST'])
+@returns_problem_detail
+def log_in_w_token():
+    return current_app.library_registry.admin_controller.log_in_w_token()
+
+
+# We are using the `refresh=True` options in jwt_required to only allow
+# refresh tokens to access this route.
+@admin.route('/admin/refresh', methods=['POST'])
+@returns_problem_detail
+@jwt_required(refresh=True)
+def refresh():
+    return current_app.library_registry.admin_controller.refresh()
+
 
 @admin.route('/admin/log_out')
 @check_logged_in
@@ -25,11 +46,13 @@ def log_in():
 def log_out():
     return current_app.library_registry.admin_controller.log_out()
 
+
 @admin.route('/admin/libraries')
 @check_logged_in
 @returns_json_or_response_or_problem_detail
 def libraries():
     return current_app.library_registry.admin_controller.libraries()
+
 
 @admin.route('/admin/libraries/qa')
 @check_logged_in
@@ -37,11 +60,13 @@ def libraries():
 def libraries_qa_admin():
     return current_app.library_registry.admin_controller.libraries(live=False)
 
+
 @admin.route('/admin/libraries/<uuid>')
 @check_logged_in
 @returns_json_or_response_or_problem_detail
 def library_details(uuid):
     return current_app.library_registry.admin_controller.library_details(uuid)
+
 
 @admin.route('/admin/libraries/search_details', methods=["POST"])
 @check_logged_in
@@ -49,17 +74,20 @@ def library_details(uuid):
 def search_details():
     return current_app.library_registry.admin_controller.search_details()
 
+
 @admin.route('/admin/libraries/email', methods=["POST"])
 @check_logged_in
 @returns_json_or_response_or_problem_detail
 def validate_email():
     return current_app.library_registry.admin_controller.validate_email()
 
+
 @admin.route('/admin/libraries/registration', methods=["POST"])
 @check_logged_in
 @returns_json_or_response_or_problem_detail
 def edit_registration():
     return current_app.library_registry.admin_controller.edit_registration()
+
 
 @admin.route('/admin/libraries/pls_id', methods=["POST"])
 @check_logged_in

--- a/library_registry/app.py
+++ b/library_registry/app.py
@@ -42,6 +42,7 @@ def create_app(testing=False, db_session_obj=None):
     app.register_blueprint(libr_list)
     babel.init_app(app)
 
+    # Options for JWT Token Locations ["headers", "cookies", "json", "query_string"]
     app.config['JWT_TOKEN_LOCATION'] = ['cookies', 'headers']
     app.config['JWT_COOKIE_CSRF_PROTECT'] = True
     app.config['JWT_CSRF_CHECK_FORM'] = True

--- a/library_registry/app.py
+++ b/library_registry/app.py
@@ -42,8 +42,6 @@ def create_app(testing=False, db_session_obj=None):
     app.register_blueprint(libr_list)
     babel.init_app(app)
 
-    app.config['JWT_SECRET_KEY'] = 'super-secret'  # Change this!
-
     app.config['JWT_TOKEN_LOCATION'] = ['cookies', 'headers']
     app.config['JWT_COOKIE_CSRF_PROTECT'] = True
     app.config['JWT_CSRF_CHECK_FORM'] = True

--- a/library_registry/app.py
+++ b/library_registry/app.py
@@ -42,8 +42,12 @@ def create_app(testing=False, db_session_obj=None):
     app.register_blueprint(libr_list)
     babel.init_app(app)
 
+    app.config['JWT_SECRET_KEY'] = 'super-secret'  # Change this!
+
+    app.config['JWT_TOKEN_LOCATION'] = ['cookies', 'headers']
+    app.config['JWT_COOKIE_CSRF_PROTECT'] = True
+    app.config['JWT_CSRF_CHECK_FORM'] = True
     jwt = JWTManager(app)
-    # app.secret_key = Configuration.SECRET_KEY
 
     if testing and db_session_obj:
         _db = db_session_obj

--- a/library_registry/app.py
+++ b/library_registry/app.py
@@ -2,6 +2,7 @@
 import os
 import sys
 import urllib.parse
+from datetime import datetime, timezone, timedelta
 
 from flask import Flask
 from flask_babel import Babel

--- a/library_registry/app.py
+++ b/library_registry/app.py
@@ -3,7 +3,7 @@ import os
 import sys
 import urllib.parse
 
-from flask import Flask, Response
+from flask import Flask
 from flask_babel import Babel
 from flask_sqlalchemy_session import flask_scoped_session
 
@@ -42,11 +42,15 @@ def create_app(testing=False, db_session_obj=None):
     app.register_blueprint(libr_list)
     babel.init_app(app)
 
+    # =============Flask JWT Config Begin===================
+
     # Options for JWT Token Locations ["headers", "cookies", "json", "query_string"]
     app.config['JWT_TOKEN_LOCATION'] = ['cookies', 'headers']
     app.config['JWT_COOKIE_CSRF_PROTECT'] = True
     app.config['JWT_CSRF_CHECK_FORM'] = True
     jwt = JWTManager(app)
+
+    # =============Flask JWT Config End=====================
 
     if testing and db_session_obj:
         _db = db_session_obj

--- a/library_registry/app.py
+++ b/library_registry/app.py
@@ -49,6 +49,7 @@ def create_app(testing=False, db_session_obj=None):
     app.config['JWT_TOKEN_LOCATION'] = ['cookies', 'headers']
     app.config['JWT_COOKIE_CSRF_PROTECT'] = True
     app.config['JWT_CSRF_CHECK_FORM'] = True
+    app.config['SECRET_KEY'] = Configuration.SECRET_KEY
     jwt = JWTManager(app)
 
     # =============Flask JWT Config End=====================

--- a/library_registry/app.py
+++ b/library_registry/app.py
@@ -46,7 +46,7 @@ def create_app(testing=False, db_session_obj=None):
     # =============Flask JWT Config Begin===================
 
     # Options for JWT Token Locations ["headers", "cookies", "json", "query_string"]
-    app.config['JWT_TOKEN_LOCATION'] = ['cookies', 'headers']
+    app.config['JWT_TOKEN_LOCATION'] = ['headers']
     app.config['JWT_COOKIE_CSRF_PROTECT'] = True
     app.config['JWT_CSRF_CHECK_FORM'] = True
     app.config['SECRET_KEY'] = Configuration.SECRET_KEY

--- a/tests/test_controller.py
+++ b/tests/test_controller.py
@@ -1,17 +1,14 @@
 import base64
 import datetime
-from http import cookiejar
 import json
 import random
 from contextlib import contextmanager
 from smtplib import SMTPException
 from urllib.parse import unquote
-from datetime import timedelta
-import requests
 
 import pytest       # noqa: F401
 import flask
-from flask import Response, session, url_for
+from flask import Response, session
 from werkzeug.datastructures import ImmutableMultiDict, MultiDict, ImmutableDict
 from Crypto.PublicKey import RSA
 from Crypto.Cipher import PKCS1_OAEP
@@ -2030,8 +2027,7 @@ class TestAdminController:
         db_session.delete(admin)
         db_session.commit()
 
-    def test_log_out_with_token(self, db_session, app, mock_admin_controller):
-        admin = Admin.authenticate(db_session, "Admin", "123")
+    def test_log_out_with_token(self, app, mock_admin_controller):
         with app.test_request_context("/"):
             access_token = create_access_token(identity='Admin')
             flask.request.headers = ImmutableDict({'Authorization': 'Bearer %s' %

--- a/tests/test_controller.py
+++ b/tests/test_controller.py
@@ -2006,8 +2006,8 @@ class TestAdminController:
     def test_log_in_with_token(self, app, mock_admin_controller):
         with app.test_request_context("/", method="POST"):
             flask.request.form = MultiDict(
-                [("username", "Admin"), ("password", "123"), ('jwt', True)])
-            response = mock_admin_controller.log_in()
+                [("username", "Admin"), ("password", "123")])
+            response = mock_admin_controller.log_in(jwt_preferred=True)
             assert response.status == "302 FOUND"
             cookiejar = response.headers.getlist('Set-Cookie')
             access_token = [

--- a/tests/test_controller.py
+++ b/tests/test_controller.py
@@ -2014,7 +2014,7 @@ class TestAdminController:
         with app.test_request_context("/", method="POST"):
             flask.request.form = MultiDict(
                 [("username", "Admin"), ("password", "123")])
-            response = mock_admin_controller.log_in(jwt_preferred=True)
+            response = mock_admin_controller.log_in(jwt_cookie_boolean=True)
             assert response.status == "302 FOUND"
             cookiejar = response.headers.getlist('Set-Cookie')
             access_token = [

--- a/tests/test_controller.py
+++ b/tests/test_controller.py
@@ -1972,7 +1972,7 @@ class TestAdminController:
             flask.request.form = MultiDict(
                 [("username", "Admin"), ("password", "123")])
             response = mock_admin_controller.log_in()
-            assert response.status == "302 FOUND"
+            assert response.status == "200 OK"
             assert session["username"] == "Admin"
 
     def test_log_in_with_error(self, db_session, app, mock_admin_controller):
@@ -1997,7 +1997,7 @@ class TestAdminController:
                 ("password", "password")
             ])
             response = mock_admin_controller.log_in()
-            assert response.status == "302 FOUND"
+            assert response.status == "200 OK"
             assert session["username"] == "New"
 
     def test_log_in_with_token(self, app, mock_admin_controller):
@@ -2015,13 +2015,11 @@ class TestAdminController:
             flask.request.form = MultiDict(
                 [("username", "Admin"), ("password", "123")])
             response = mock_admin_controller.log_in(jwt_cookie_boolean=True)
-            assert response.status == "302 FOUND"
-            cookiejar = response.headers.getlist('Set-Cookie')
-            access_token = [
-                cookie for cookie in cookiejar if 'access_token_cookie' in cookie]
-            assert len(access_token) > 0
-            decoded_token = decode_token(access_token[0][20:-18])
-            assert 'Admin' in decoded_token.get('sub')
+            print(response)
+            print(response)
+            assert response.status == "200 OK"
+            assert b'access_token' in response.data
+            assert b'refresh_token' in response.data
 
     def test_log_out(self, db_session, app, mock_admin_controller):
         admin = Admin.authenticate(db_session, "Admin", "123")

--- a/tests/test_controller.py
+++ b/tests/test_controller.py
@@ -1971,8 +1971,8 @@ class TestAdminController:
         with app.test_request_context("/", method="POST"):
             flask.request.form = MultiDict(
                 [("username", "Admin"), ("password", "123")])
-            response = mock_admin_controller.log_in()
-            assert response.status == "200 OK"
+            response = mock_admin_controller.log_in(None)
+            assert response.status == "302 FOUND"
             assert session["username"] == "Admin"
 
     def test_log_in_with_error(self, db_session, app, mock_admin_controller):
@@ -1982,7 +1982,7 @@ class TestAdminController:
                 ("username", "Admin"),
                 ("password", "wrong"),
             ])
-            response = mock_admin_controller.log_in()
+            response = mock_admin_controller.log_in(None)
             assert(isinstance(response, ProblemDetail))
             assert response.status_code == 401
             assert response.title == INVALID_CREDENTIALS.title
@@ -1996,8 +1996,8 @@ class TestAdminController:
                 ("username", "New"),
                 ("password", "password")
             ])
-            response = mock_admin_controller.log_in()
-            assert response.status == "200 OK"
+            response = mock_admin_controller.log_in(None)
+            assert response.status == "302 FOUND"
             assert session["username"] == "New"
 
     def test_log_in_with_token(self, app, mock_admin_controller):
@@ -2014,7 +2014,7 @@ class TestAdminController:
         with app.test_request_context("/", method="POST"):
             flask.request.form = MultiDict(
                 [("username", "Admin"), ("password", "123")])
-            response = mock_admin_controller.log_in(jwt_cookie_boolean=True)
+            response = mock_admin_controller.log_in('header')
             print(response)
             print(response)
             assert response.status == "200 OK"
@@ -2026,12 +2026,12 @@ class TestAdminController:
         with app.test_request_context("/"):
             flask.request.form = MultiDict(
                 [("username", "Admin"), ("password", "123")])
-            mock_admin_controller.log_in()
+            mock_admin_controller.log_in(None)
 
             assert session["username"] == "Admin"
             response = mock_admin_controller.log_out()
             assert session["username"] == ""
-            assert response.status == "200 OK"
+            assert response.status == "302 FOUND"
         db_session.delete(admin)
         db_session.commit()
 

--- a/tests/test_controller.py
+++ b/tests/test_controller.py
@@ -16,7 +16,7 @@ from werkzeug.datastructures import ImmutableMultiDict, MultiDict, ImmutableDict
 from Crypto.PublicKey import RSA
 from Crypto.Cipher import PKCS1_OAEP
 
-from flask_jwt_extended import decode_token, create_refresh_token, create_access_token
+from flask_jwt_extended import decode_token, create_access_token
 
 from library_registry.authentication_document import AuthenticationDocument
 from library_registry.config import Configuration
@@ -2012,20 +2012,15 @@ class TestAdminController:
             cookiejar = response.headers.getlist('Set-Cookie')
             access_token = [
                 cookie for cookie in cookiejar if 'access_token_cookie' in cookie]
-            refresh_token = [
-                cookie for cookie in cookiejar if 'refresh_token_cookie' in cookie]
             assert len(access_token) > 0
-            assert len(refresh_token) > 0
             decoded_token = decode_token(access_token[0][20:-18])
             assert 'Admin' in decoded_token.get('sub')
 
     def test_refresh_token(self, app, mock_admin_controller):
         with app.test_request_context("/", method="GET"):
-            refresh_token = create_refresh_token(identity='Admin')
             access_token = create_access_token(
                 identity='Admin', expires_delta=timedelta(minutes=10))
             flask.request.headers = ImmutableDict({
-                'Authorization': 'Bearer %s' % refresh_token,
                 'Authorization': 'Bearer %s' % access_token
             })
             response = mock_admin_controller.libraries()
@@ -2065,6 +2060,5 @@ class TestAdminController:
                                                    access_token})
 
             response = mock_admin_controller.log_out()
-            print([x for x in response.headers])
             assert 'access_token_cookie=;' in response.headers.get(
                 'Set-Cookie')

--- a/tests/test_controller.py
+++ b/tests/test_controller.py
@@ -2024,7 +2024,6 @@ class TestAdminController:
                 'Authorization': 'Bearer %s' % access_token
             })
             response = mock_admin_controller.libraries()
-            print(response)
             cookiejar = response.headers.getlist('Set-Cookie')
             assert [
                 cookie for cookie in cookiejar if 'access_token_cookie' in cookie]
@@ -2033,7 +2032,6 @@ class TestAdminController:
     def test_refresh_token_no_token_in_request(self, app, mock_admin_controller):
         with app.test_request_context("/", method="POST"):
             response = mock_admin_controller.libraries()
-            print(response.status_code)
             assert isinstance(response, ProblemDetail)
             assert response.status_code == 401
             assert response.title == INVALID_CREDENTIALS.title

--- a/tests/test_controller.py
+++ b/tests/test_controller.py
@@ -2060,5 +2060,6 @@ class TestAdminController:
                                                    access_token})
 
             response = mock_admin_controller.log_out()
+            # Assert access token cookie has bee revoked
             assert 'access_token_cookie=;' in response.headers.get(
                 'Set-Cookie')

--- a/tests/test_controller.py
+++ b/tests/test_controller.py
@@ -13,7 +13,7 @@ from werkzeug.datastructures import ImmutableMultiDict, MultiDict, ImmutableDict
 from Crypto.PublicKey import RSA
 from Crypto.Cipher import PKCS1_OAEP
 
-from flask_jwt_extended import decode_token, create_access_token, create_refresh_token
+from flask_jwt_extended import create_access_token, create_refresh_token
 
 from library_registry.authentication_document import AuthenticationDocument
 from library_registry.config import Configuration

--- a/tests/test_controller.py
+++ b/tests/test_controller.py
@@ -2014,7 +2014,7 @@ class TestAdminController:
         with app.test_request_context("/", method="POST"):
             flask.request.form = MultiDict(
                 [("username", "Admin"), ("password", "123")])
-            response = mock_admin_controller.log_in('header')
+            response = mock_admin_controller.log_in('jwt')
             print(response)
             print(response)
             assert response.status == "200 OK"

--- a/tests/test_controller.py
+++ b/tests/test_controller.py
@@ -2001,6 +2001,16 @@ class TestAdminController:
             assert session["username"] == "New"
 
     def test_log_in_with_token(self, app, mock_admin_controller):
+        """Test JWT token log in
+
+        Args:
+            app (FlaskApp): Flask testing environment
+            mock_admin_controller (AdminControllerClass): mocked controller for calls
+
+        GIVEN: jwt_preferred=True
+        WHEN: A request is sent to the log_in method
+        THEN: A cookie with the identity of the user will be returned
+        """
         with app.test_request_context("/", method="POST"):
             flask.request.form = MultiDict(
                 [("username", "Admin"), ("password", "123")])
@@ -2028,6 +2038,16 @@ class TestAdminController:
         db_session.commit()
 
     def test_log_out_with_token(self, app, mock_admin_controller):
+        """Test JWT token log in
+
+        Args:
+            app (FlaskApp): Flask testing environment
+            mock_admin_controller (AdminControllerClass): mocked controller for calls
+
+        GIVEN: An authorized token in headers
+        WHEN: A call to the log_out method
+        THEN: The access token cookie will be unset
+        """
         with app.test_request_context("/"):
             access_token = create_access_token(identity='Admin')
             flask.request.headers = ImmutableDict({'Authorization': 'Bearer %s' %

--- a/tests/test_controller.py
+++ b/tests/test_controller.py
@@ -2016,26 +2016,6 @@ class TestAdminController:
             decoded_token = decode_token(access_token[0][20:-18])
             assert 'Admin' in decoded_token.get('sub')
 
-    def test_refresh_token(self, app, mock_admin_controller):
-        with app.test_request_context("/", method="GET"):
-            access_token = create_access_token(
-                identity='Admin', expires_delta=timedelta(minutes=10))
-            flask.request.headers = ImmutableDict({
-                'Authorization': 'Bearer %s' % access_token
-            })
-            response = mock_admin_controller.libraries()
-            cookiejar = response.headers.getlist('Set-Cookie')
-            assert [
-                cookie for cookie in cookiejar if 'access_token_cookie' in cookie]
-            assert response.status == '201 CREATED'
-
-    def test_refresh_token_no_token_in_request(self, app, mock_admin_controller):
-        with app.test_request_context("/", method="POST"):
-            response = mock_admin_controller.libraries()
-            assert isinstance(response, ProblemDetail)
-            assert response.status_code == 401
-            assert response.title == INVALID_CREDENTIALS.title
-
     def test_log_out(self, db_session, app, mock_admin_controller):
         admin = Admin.authenticate(db_session, "Admin", "123")
         with app.test_request_context("/"):

--- a/tests/test_controller.py
+++ b/tests/test_controller.py
@@ -2031,30 +2031,9 @@ class TestAdminController:
             assert session["username"] == "Admin"
             response = mock_admin_controller.log_out()
             assert session["username"] == ""
-            assert response.status == "302 FOUND"
+            assert response.status == "200 OK"
         db_session.delete(admin)
         db_session.commit()
-
-    def test_log_out_with_token(self, app, mock_admin_controller):
-        """Test JWT token log out
-
-        Args:
-            app (FlaskApp): Flask testing environment
-            mock_admin_controller (AdminControllerClass): mocked controller for calls
-
-        GIVEN: An authorized token in headers
-        WHEN: A call to the log_out method
-        THEN: The access token cookie will be unset
-        """
-        with app.test_request_context("/"):
-            access_token = create_access_token(identity='Admin')
-            flask.request.headers = ImmutableDict({'Authorization': 'Bearer %s' %
-                                                   access_token})
-
-            response = mock_admin_controller.log_out()
-            # Assert access token cookie has bee revoked
-            assert 'access_token_cookie=;' in response.headers.get(
-                'Set-Cookie')
 
     def test_refresh_token(self, app, mock_admin_controller):
         """Test JWT token refresh

--- a/tests/test_decorators.py
+++ b/tests/test_decorators.py
@@ -325,7 +325,7 @@ class TestDecorators:
                     '/test/check_logged_in')
                 assert response.status == '401 UNAUTHORIZED'
 
-    def test_after_request_jwt_token_refresh(self, app_with_decorated_routes):
+    def test_after_request_jwt_cookie_refresh(self, app_with_decorated_routes):
         """Test check logged in decorator without JWT token 
 
         Args:
@@ -339,12 +339,14 @@ class TestDecorators:
             with app_with_decorated_routes.test_client() as client:
                 access_token = create_access_token(
                     identity='Admin', expires_delta=timedelta(minutes=10))
+                client.set_cookie(
+                    'localhost', 'access_token_cookie', access_token)
                 response = client.get(
-                    '/test/check_logged_in', headers={'Authorization': 'Bearer %s' % access_token})
+                    '/test/check_logged_in')
                 assert response.status == '201 CREATED'
                 assert response.data.decode('utf-8') == RESPONSE_OBJ_VAL
 
-    def test_expired_jwt_token_access(self, app_with_decorated_routes):
+    def test_jwt_expired_auth_point_access(self, app_with_decorated_routes):
         """Test check logged in decorator without JWT token 
 
         Args:
@@ -362,3 +364,11 @@ class TestDecorators:
                 response = client.get(
                     '/test/check_logged_in', headers={'Authorization': 'Bearer %s' % access_token})
                 assert response.status == '401 UNAUTHORIZED'
+
+    def test_jwt_in_header_after_request(self, app_with_decorated_routes):
+        with app_with_decorated_routes.app_context():
+            with app_with_decorated_routes.test_client() as client:
+                access_token = create_access_token(identity='Admin')
+                response = client.get(
+                    '/test/check_logged_in', headers={'Authorization': 'Bearer %s' % access_token})
+                assert response.status == '200 OK'

--- a/tests/test_decorators.py
+++ b/tests/test_decorators.py
@@ -326,14 +326,14 @@ class TestDecorators:
                 assert response.status == '401 UNAUTHORIZED'
 
     def test_after_request_jwt_cookie_refresh(self, app_with_decorated_routes):
-        """Test check logged in decorator without JWT token 
+        """Test after_request decorator with JWT cookie 
 
         Args:
             app_with_decorated_routes (FlaskApp): Flask test enivironment.
 
-        GIVEN:  A no valid JWT token in header
+        GIVEN:  A JWT token in cookies
         WHEN:   The view function  wrapped by @check_logged_in is called
-        THEN:   The a RESPONSE_OBJ_VAL response should be received
+        THEN:   The a RESPONSE_OBJ_VAL response should be received and 201 CREATED code
         """
         with app_with_decorated_routes.app_context():
             with app_with_decorated_routes.test_client() as client:
@@ -347,12 +347,12 @@ class TestDecorators:
                 assert response.data.decode('utf-8') == RESPONSE_OBJ_VAL
 
     def test_jwt_expired_auth_point_access(self, app_with_decorated_routes):
-        """Test check logged in decorator without JWT token 
+        """Test check logged in decorator with expired JWT token 
 
         Args:
             app_with_decorated_routes (FlaskApp): Flask test enivironment.
 
-        GIVEN:  A no valid JWT token in header
+        GIVEN:  An expired JWT token in header
         WHEN:   The view function  wrapped by @check_logged_in is called
         THEN:   The a 401 UNAUTHORIZED response should be received
         """
@@ -365,10 +365,20 @@ class TestDecorators:
                     '/test/check_logged_in', headers={'Authorization': 'Bearer %s' % access_token})
                 assert response.status == '401 UNAUTHORIZED'
 
-    def test_jwt_in_header_after_request(self, app_with_decorated_routes):
+    def test_after_request_jwt_in_header_(self, app_with_decorated_routes):
+        """Test after_request decorator with JWT in header 
+
+        Args:
+            app_with_decorated_routes (FlaskApp): Flask test enivironment.
+
+        GIVEN:  A JWT token in header
+        WHEN:   The view function  wrapped by @check_logged_in is called
+        THEN:   The a RESPONSE_OBJ_VAL response should be received and 200 OK code
+        """
         with app_with_decorated_routes.app_context():
             with app_with_decorated_routes.test_client() as client:
                 access_token = create_access_token(identity='Admin')
                 response = client.get(
                     '/test/check_logged_in', headers={'Authorization': 'Bearer %s' % access_token})
                 assert response.status == '200 OK'
+                assert response.data.decode('utf-8') == RESPONSE_OBJ_VAL

--- a/tests/test_decorators.py
+++ b/tests/test_decorators.py
@@ -349,7 +349,5 @@ class TestDecorators:
                     identity='Admin', expires_delta=timedelta(minutes=10))
                 response = client.get(
                     '/test/check_logged_in', headers={'Authorization': 'Bearer %s' % access_token})
-                cookiejar = response.headers.getlist('Set-Cookie')
-                print(cookiejar)
                 assert response.status == '201 CREATED'
                 assert response.data.decode('utf-8') == RESPONSE_OBJ_VAL

--- a/tests/test_decorators.py
+++ b/tests/test_decorators.py
@@ -39,7 +39,7 @@ def app():
     babel.init_app(app)
     app.config['JWT_SECRET_KEY'] = 'testing'
     jwt = JWTManager(app)
-    app.config['JWT_TOKEN_LOCATION'] = ['cookies', 'headers']
+    app.config['JWT_TOKEN_LOCATION'] = ['headers']
     return(app)
 
 


### PR DESCRIPTION
## Description

Implement Flask-JWT-Extended functionality for admin routes.  Modified routes admin/log_in and @check_logged_in decorator have been extended to handle both Flask session and Flask JWT procedures. Add admin/refresh to refresh expiring tokens explicitly. 

## Motivation and Context

[SIMPLY-4132](https://jira.nypl.org/browse/SIMPLY-4132) 
[SIMPLY-4133](https://jira.nypl.org/browse/SIMPLY-4133)
[SIMPLY-4145](https://jira.nypl.org/browse/SIMPLY-4145)
Implement Flask JWT for a more restful API implementing Explicit Header access tokens enabling us to move away from flask sessions. 

## How Has This Been Tested?

Added a tests to confirm functionality of log in and refresh functions and @check_logged_in decorators.

## Checklist:

[x] I have updated the documentation accordingly.
[x] All new and existing tests passed.
[x] Modified code base commented