### PR TITLE
Add support for JWT credentials to CORS handling.

### DIFF
--- a/library_registry/app.py
+++ b/library_registry/app.py
@@ -38,7 +38,7 @@ db_url = Configuration.database_url(test=TESTING)
 def create_app(testing=False, db_session_obj=None):
 
     app = Flask(__name__)
-    CORS(app)
+    CORS(app, supports_credentials=True)
     app.register_blueprint(drm)
     app.register_blueprint(admin)
     app.register_blueprint(libr)


### PR DESCRIPTION
## Description

<!--- Describe your changes -->
Added support for CORS handling of credentials

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
New library registry admin pages are receiving CORS errors.  This is due to default of Flask CORS.  The option for support_credentials just needs to be turned on to accept JWT.

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->


## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
